### PR TITLE
Implement Into/TryFrom BoltType for Vec and Into for f64

### DIFF
--- a/lib/src/convert.rs
+++ b/lib/src/convert.rs
@@ -3,6 +3,22 @@ use crate::row::*;
 use crate::types::*;
 use std::convert::{TryFrom, TryInto};
 
+impl<A: TryFrom<BoltType>> TryFrom<BoltType> for Vec<A> {
+    type Error = Error;
+
+    fn try_from(input: BoltType) -> Result<Vec<A>> {
+        match input {
+            BoltType::List(l) => Ok(l.value
+                                    .to_vec()
+                                    .iter()
+                                    .flat_map(|x| A::try_from(x.clone()))
+                                    .collect()
+                                    ),
+            _ => Err(Error::ConverstionError),
+        }
+    }
+}
+
 impl TryFrom<BoltType> for f64 {
     type Error = Error;
 
@@ -259,9 +275,25 @@ impl Into<BoltType> for (chrono::NaiveDateTime, &str) {
     }
 }
 
+impl<A: Into<BoltType> + Clone> Into<BoltType> for Vec<A> {
+    fn into(self) -> BoltType {
+        BoltType::List(BoltList {
+            value: self
+                .iter()
+                .map(|v| v.clone().into())
+                .collect()})
+    }
+}
+
 impl Into<BoltType> for Vec<u8> {
     fn into(self) -> BoltType {
         BoltType::Bytes(BoltBytes::new(self.into()))
+    }
+}
+
+impl Into<BoltType> for f64 {
+    fn into(self) -> BoltType {
+        BoltType::Float(BoltFloat::new(self))
     }
 }
 

--- a/lib/src/convert.rs
+++ b/lib/src/convert.rs
@@ -273,10 +273,16 @@ impl Into<BoltType> for (chrono::NaiveDateTime, &str) {
 impl<A: Into<BoltType> + Clone> Into<BoltType> for Vec<A> {
     fn into(self) -> BoltType {
         BoltType::List(BoltList {
-            value: self
-                .iter()
-                .map(|v| v.clone().into())
-                .collect()})
+            value: self.iter().map(|v| v.clone().into()).collect(),
+        })
+    }
+}
+
+impl<A: Into<BoltType> + Clone> Into<BoltType> for &[A] {
+    fn into(self) -> BoltType {
+        BoltType::List(BoltList {
+            value: self.iter().map(|v| v.clone().into()).collect(),
+        })
     }
 }
 
@@ -336,5 +342,35 @@ mod tests {
         });
         let value = Vec::<i64>::try_from(value).unwrap_err();
         assert!(matches!(value, Error::ConverstionError));
+    }
+
+    #[test]
+    fn convert_from_vec() {
+        let value: Vec<i64> = vec![42, 1337];
+        let value: BoltType = value.into();
+        assert_eq!(
+            value,
+            BoltType::List(BoltList {
+                value: vec![
+                    BoltType::Integer(BoltInteger::new(42)),
+                    BoltType::Integer(BoltInteger::new(1337)),
+                ],
+            })
+        );
+    }
+
+    #[test]
+    fn convert_from_slice() {
+        let value: Vec<i64> = vec![42, 1337];
+        let value: BoltType = value.as_slice().into();
+        assert_eq!(
+            value,
+            BoltType::List(BoltList {
+                value: vec![
+                    BoltType::Integer(BoltInteger::new(42)),
+                    BoltType::Integer(BoltInteger::new(1337)),
+                ],
+            })
+        );
     }
 }


### PR DESCRIPTION
In its current state, neo4rs does not appear to support lists/vectors in node properties and probably elsewhere due to missing `Into` and `TryFrom` implementations. This patch firstly adds support for `Vec<A>` given `A` is already convertible to/from `BoltType`. Secondly, an implementation of `Into<BoltType> for f64` is provided, as this seems to be already supported the other way around.

These changes together should allow using neo4rs to work with databases containing vector embeddings. Edits by maintainers are on, so feel free to edit anything if it's not up to standard.