### PR TITLE
Rework the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,36 +16,56 @@ This driver is compatible with neo4j 4.x versions
 ## Example
 
 ```rust    
-    // concurrent queries
-    let uri = "127.0.0.1:7687";
-    let user = "neo4j";
-    let pass = "neo";
-    let graph = Arc::new(Graph::new(&uri, user, pass).await.unwrap());
-    for _ in 1..=42 {
-        let graph = graph.clone();
-        tokio::spawn(async move {
-            let mut result = graph.execute(
-	       query("MATCH (p:Person {name: $name}) RETURN p").param("name", "Mark")
-	    ).await.unwrap();
-            while let Ok(Some(row)) = result.next().await {
-        	let node: Node = row.get("p").unwrap();
-        	let name: String = node.get("name").unwrap();
-                println!("{}", name);
-            }
-        });
+use neo4rs::{Graph, Node, query};
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() {
+  // concurrent queries
+  let uri = "127.0.0.1:7687";
+  let user = "neo4j";
+  let pass = "neo";
+  let graph = Arc::new(Graph::new(uri, user, pass).await.unwrap());
+  let q = graph.clone();
+  let mut tasks = std::vec::Vec::new();
+
+  tasks.push(tokio::spawn(async move {
+    loop {
+      let mut result = q.execute(
+        query("MATCH (p:Person {name: $name}) RETURN p").param("name", "mark"))
+        .await.unwrap();
+
+      tokio::select! {
+        Ok(maybe_row) = result.next() => {
+          match maybe_row {
+            Some(row) => {
+              let node: Node = row.get("p").unwrap();
+              let name: String = node.get("name").unwrap();
+              println!("Found {} in the graph", name);
+              return;
+            },
+            None      => println!("Waiting for mark to be added to the graph")
+          }
+        },
+      }
     }
-    
-    //Transactions
-    let mut txn = graph.start_txn().await.unwrap();
-    txn.run_queries(vec![
-        query("CREATE (p:Person {name: 'mark'})"),
-        query("CREATE (p:Person {name: 'jake'})"),
-        query("CREATE (p:Person {name: 'luke'})"),
-    ])
-    .await
-    .unwrap();
-    txn.commit().await.unwrap(); //or txn.rollback().await.unwrap();
-    
+  }));
+
+  //Transactions
+  let txn = graph.start_txn().await.unwrap();
+
+  txn.run_queries(vec![
+    query("CREATE (p:Person {name: 'mark'})"),
+    query("CREATE (p:Person {name: 'jake'})"),
+    query("CREATE (p:Person {name: 'luke'})"),
+  ])
+  .await
+  .unwrap();
+
+  txn.commit().await.unwrap(); //or txn.rollback().await.unwrap();
+
+  futures::future::join_all(tasks).await;
+}
 ```
 
 


### PR DESCRIPTION
I am trying graph databases for the first time and ran this example. It compiled and inserted nodes into my neo4j container, but it did not print when Mark was found. I believe this will provide a fix for new users of this crate so they can understand what to expect.

Below are the fixes I identified:

- Query for `mark` instead of `Mark`, because neo4j is case-sensitive.
- Spawn query tasks until `mark` is found, rather than spawning 42 async tasks which may all exit before the nodes are inserted into the graph.
- Join on all tasks so that we always insert nodes into the graph and always query for `mark` before exiting.