### PR TITLE
Eliminate warnings and deprecations from docs

### DIFF
--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -3,7 +3,7 @@ pub use crate::errors::*;
 const DEFAULT_FETCH_SIZE: usize = 200;
 const DEFAULT_MAX_CONNECTIONS: usize = 16;
 
-/// The configuration used to connect to the database, see [`Graph::connect`]
+/// The configuration used to connect to the database, see [`crate::Graph::connect`]
 #[derive(Debug, Clone)]
 pub struct Config {
     pub(crate) uri: String,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -482,7 +482,7 @@
 //!    let user = "neo4j";
 //!    let pass = "neo";
 //!    let graph = Graph::new(uri, user, pass).await.unwrap();
-//!    let date = chrono::NaiveDate::from_ymd(1985, 2, 5);
+//!    let date = chrono::NaiveDate::from_ymd_opt(1985, 2, 5).unwrap();
 //!    let mut result = graph
 //!        .execute(query("RETURN $d as output").param("d", date))
 //!        .await
@@ -522,7 +522,7 @@
 //!    let graph = Graph::new(uri, user, pass).await.unwrap();
 //!
 //!    //send time without offset as param
-//!    let time = chrono::NaiveTime::from_hms_nano(11, 15, 30, 200);
+//!    let time = chrono::NaiveTime::from_hms_nano_opt(11, 15, 30, 200).unwrap();
 //!    let mut result = graph.execute(query("RETURN $d as output").param("d", time)).await.unwrap();
 //!    let row = result.next().await.unwrap().unwrap();
 //!    let t: (chrono::NaiveTime, Option<chrono::FixedOffset>) = row.get("output").unwrap();
@@ -532,8 +532,8 @@
 //!
 //!
 //!    //send time with offset as param
-//!    let time = chrono::NaiveTime::from_hms_nano(11, 15, 30, 200);
-//!    let offset = chrono::FixedOffset::east(3 * 3600);
+//!    let time = chrono::NaiveTime::from_hms_nano_opt(11, 15, 30, 200).unwrap();
+//!    let offset = chrono::FixedOffset::east_opt(3 * 3600).unwrap();
 //!    let mut result = graph
 //!        .execute(query("RETURN $d as output").param("d", (time, offset)))
 //!        .await
@@ -584,7 +584,7 @@
 //!    let row = result.next().await.unwrap().unwrap();
 //!    let t: (chrono::NaiveTime, Option<chrono::FixedOffset>) = row.get("t").unwrap();
 //!    assert_eq!(t.0.to_string(), "10:15:33.000000200");
-//!    assert_eq!(t.1, Some(chrono::FixedOffset::east(1 * 3600)));
+//!    assert_eq!(t.1, Some(chrono::FixedOffset::east_opt(1 * 3600).unwrap()));
 //!    assert!(result.next().await.unwrap().is_none());
 //! }
 //!

--- a/lib/src/stream.rs
+++ b/lib/src/stream.rs
@@ -7,8 +7,8 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-/// An abstraction over a stream of rows, this is returned as a result of [`Graph::execute`] or
-/// [`Txn::execute`] operations
+/// An abstraction over a stream of rows, this is returned as a result of [`crate::Graph::execute`] or
+/// [`crate::Txn::execute`] operations
 ///
 /// A stream will contain a connection from the connection pool which will be released to the pool
 /// when the stream is dropped.
@@ -48,7 +48,7 @@ impl RowStream {
 
     /// A call to next() will return a row from an internal buffer if the buffer has any entries,
     /// if the buffer is empty and the server has more rows left to consume, then a new batch of rows are fetched from the server (using the
-    /// fetch_size value configured see [`ConfigBuilder::fetch_size`])
+    /// fetch_size value configured see [`crate::ConfigBuilder::fetch_size`])
     pub async fn next(&mut self) -> Result<Option<Row>> {
         let mut connection = self.connection.lock().await;
         loop {

--- a/lib/src/txn.rs
+++ b/lib/src/txn.rs
@@ -7,7 +7,7 @@ use crate::stream::*;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-/// A handle which is used to control a transaction, created as a result of [`Graph::start_txn`]
+/// A handle which is used to control a transaction, created as a result of [`crate::Graph::start_txn`]
 ///
 /// When a transation is started, a dedicated connection is resered and moved into the handle which
 /// will be released to the connection pool when the [`Txn`] handle is dropped.


### PR DESCRIPTION
- Fully qualify links in docs
- Don't use deprecated methods in doc tests
