### PR TITLE
Compatibility with Neo4j version 5 and 4.4.

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -377,7 +377,7 @@
 //!    let mut result = graph
 //!        .execute(query(
 //!            "WITH point({ x: 2.3, y: 4.5, crs: 'cartesian' }) AS p1,
-//!             point({ x: 1.1, y: 5.4, crs: 'cartesian' }) AS p2 RETURN distance(p1,p2) AS dist, p1, p2",
+//!             point({ x: 1.1, y: 5.4, crs: 'cartesian' }) AS p2 RETURN point.distance(p1,p2) AS dist, p1, p2",
 //!        ))
 //!        .await
 //!        .unwrap();

--- a/lib/src/messages/run.rs
+++ b/lib/src/messages/run.rs
@@ -2,7 +2,7 @@ use crate::types::*;
 use neo4rs_macros::BoltStruct;
 
 #[derive(Debug, PartialEq, Clone, BoltStruct)]
-#[signature(0xB1, 0x10)]
+#[signature(0xB3, 0x10)]
 pub struct Run {
     query: BoltString,
     parameters: BoltMap,
@@ -39,7 +39,7 @@ mod tests {
         assert_eq!(
             bytes,
             Bytes::from_static(&[
-                0xB1,
+                0xB3,
                 0x10,
                 string::TINY | 5,
                 b'q',
@@ -74,7 +74,7 @@ mod tests {
         assert_eq!(
             bytes,
             Bytes::from_static(&[
-                0xB1,
+                0xB3,
                 0x10,
                 string::TINY | 5,
                 b'q',


### PR DESCRIPTION
According to the [specification](https://neo4j.com/docs/bolt/current/packstream/) a struct with 3 fields is supposed to have the marker `B3`.

The `Run` struct was marked with `B1` instead (struct with 1 field), which causes problems with Neo4j 5.2.

After changing it to `B3` all test run successfully with versions 4.4.18 and 5.2.0.

Additionally `distance` was renamed to `point.distance` in version 4.4 ([reference](https://neo4j.com/docs/cypher-manual/4.4/functions/spatial/)).