### PR TITLE
Implement Error trait using thiserror.

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = "0.1.42"
 deadpool = "0.7.0"
 chrono = "0.4.19"
 log = "0.4"
+thiserror = "1.0.38"
 
 [dev-dependencies]
 uuid = { version = "0.8", features = ["v4"] }

--- a/lib/src/errors.rs
+++ b/lib/src/errors.rs
@@ -1,21 +1,50 @@
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("an IO error occurred")]
     IOError { detail: String },
+
+    #[error("connection error")]
     ConnectionError,
+
+    #[error("attempted to serialize excessively long string")]
     StringTooLong,
+
+    #[error("attempted to serialize excessively large map")]
     MapTooBig,
+
+    #[error("attempted to serialize excessively large byte array")]
     BytesTooBig,
+
+    #[error("attempted to serialize excessively long list")]
     ListTooLong,
+
+    #[error("invalid config")]
     InvalidConfig,
+
+    #[error("{0}")]
     UnsupportedVersion(String),
+
+    #[error("{0}")]
     UnexpectedMessage(String),
+
+    #[error("{0}")]
     UnknownType(String),
+
+    #[error("{0}")]
     UnknownMessage(String),
+
+    #[error("conversion error")]
     ConversionError,
+
+    #[error("{0}")]
     AuthenticationError(String),
+
+    #[error("{0}")]
     InvalidTypeMarker(String),
+
+    #[error("{0}")]
     DeserializationError(String),
 }
 


### PR DESCRIPTION
This implements the error trait using `thiserror`.

In general, restructuring the Error type would probably a good idea (e.g. have type and marker as fields of `InvalidMarker` instead of a message string), but that would be a breaking change.