### PR TITLE
Pass multiple params as a hashmap

### DIFF
--- a/lib/src/query.rs
+++ b/lib/src/query.rs
@@ -4,6 +4,7 @@ use crate::messages::*;
 use crate::pool::*;
 use crate::stream::*;
 use crate::types::*;
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -24,6 +25,17 @@ impl Query {
 
     pub fn param<T: std::convert::Into<BoltType>>(mut self, key: &str, value: T) -> Self {
         self.params.put(key.into(), value.into());
+        self
+    }
+
+    pub fn params<T: std::convert::Into<BoltType>>(
+        mut self,
+        input_params: HashMap<&str, T>,
+    ) -> Self {
+        for (key, value) in input_params {
+            self.params.put(key.into(), value.into());
+        }
+
         self
     }
 

--- a/lib/src/query.rs
+++ b/lib/src/query.rs
@@ -4,7 +4,6 @@ use crate::messages::*;
 use crate::pool::*;
 use crate::stream::*;
 use crate::types::*;
-use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -23,15 +22,16 @@ impl Query {
         }
     }
 
-    pub fn param<T: std::convert::Into<BoltType>>(mut self, key: &str, value: T) -> Self {
+    pub fn param<T: Into<BoltType>>(mut self, key: &str, value: T) -> Self {
         self.params.put(key.into(), value.into());
         self
     }
 
-    pub fn params<T: std::convert::Into<BoltType>>(
-        mut self,
-        input_params: HashMap<&str, T>,
-    ) -> Self {
+    pub fn params<K, V>(mut self, input_params: impl IntoIterator<Item = (K, V)>) -> Self
+    where
+        K: Into<BoltString>,
+        V: Into<BoltType>,
+    {
         for (key, value) in input_params {
             self.params.put(key.into(), value.into());
         }
@@ -74,5 +74,25 @@ impl Query {
             }
             msg => Err(unexpected(msg, "RUN")),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_params() {
+        let q = Query::new("MATCH (n) WHERE n.name = $name AND n.age > $age RETURN n".to_owned());
+        let q = q.params([
+            ("name", BoltType::from("Frobniscante")),
+            ("age", BoltType::from(42)),
+        ]);
+
+        assert_eq!(
+            q.params.get::<String>("name").unwrap(),
+            String::from("Frobniscante")
+        );
+        assert_eq!(q.params.get::<i64>("age").unwrap(), 42);
     }
 }


### PR DESCRIPTION
Here we can pass params as a standard hashmap.

Reason being it is tedious to keep calling param constantly for each new input. 

This will make it more pleasing to work with as a lot of people already have hashmaps in their projects.