### PR TITLE
Adding a `keys` function for Nodes and Relations

### DIFF
--- a/lib/src/row.rs
+++ b/lib/src/row.rs
@@ -141,6 +141,15 @@ impl Node {
     pub fn get<T: std::convert::TryFrom<BoltType>>(&self, key: &str) -> Option<T> {
         self.inner.get(key)
     }
+
+    /// Get the keys for the node's attributes
+    pub fn keys(&self) -> Vec<String> {
+        self.inner.keys().into_iter().map(
+            |key: BoltString| -> String {
+                key.to_string()
+            }
+        ).collect::<Vec<String>>()
+    }
 }
 
 impl Relation {

--- a/lib/src/row.rs
+++ b/lib/src/row.rs
@@ -120,6 +120,7 @@ impl Row {
     pub fn get<T: std::convert::TryFrom<BoltType>>(&self, key: &str) -> Option<T> {
         self.attributes.get(key)
     }
+    
 }
 
 impl Node {
@@ -201,5 +202,14 @@ impl UnboundedRelation {
 
     pub fn get<T: std::convert::TryFrom<BoltType>>(&self, key: &str) -> Option<T> {
         self.inner.get(key)
+    }
+
+    /// Get the keys for the relationships's attributes
+    pub fn keys(&self) -> Vec<String> {
+        self.inner.keys().into_iter().map(
+            |key: BoltString| -> String {
+                key.to_string()
+            }
+        ).collect::<Vec<String>>()
     }
 }

--- a/lib/src/row.rs
+++ b/lib/src/row.rs
@@ -176,6 +176,14 @@ impl Relation {
     pub fn get<T: std::convert::TryFrom<BoltType>>(&self, key: &str) -> Option<T> {
         self.inner.get(key)
     }
+    /// Get the keys for the relationships's attributes
+    pub fn keys(&self) -> Vec<String> {
+        self.inner.keys().into_iter().map(
+            |key: BoltString| -> String {
+                key.to_string()
+            }
+        ).collect::<Vec<String>>()
+    }
 }
 
 impl UnboundedRelation {

--- a/lib/src/types/node.rs
+++ b/lib/src/types/node.rs
@@ -25,6 +25,12 @@ impl BoltNode {
     }
 }
 
+impl BoltNode {
+    pub fn keys(&self) -> Vec<BoltString> {
+        self.properties.value.keys().cloned().collect()
+    }
+}
+
 impl From<BoltNode> for BoltType {
     fn from(value: BoltNode) -> Self {
         BoltType::Node(value)

--- a/lib/src/types/relation.rs
+++ b/lib/src/types/relation.rs
@@ -46,6 +46,10 @@ impl BoltUnboundedRelation {
     pub fn get<T: std::convert::TryFrom<BoltType>>(&self, key: &str) -> Option<T> {
         self.properties.get(key)
     }
+
+    pub fn keys(&self) -> Vec<BoltString> {
+        self.properties.value.keys().cloned().collect()
+    }
 }
 
 impl From<BoltRelation> for BoltType {

--- a/lib/src/types/relation.rs
+++ b/lib/src/types/relation.rs
@@ -35,6 +35,13 @@ impl BoltRelation {
     }
 }
 
+
+impl BoltRelation {
+    pub fn keys(&self) -> Vec<BoltString> {
+        self.properties.value.keys().cloned().collect()
+    }
+}
+
 impl BoltUnboundedRelation {
     pub fn get<T: std::convert::TryFrom<BoltType>>(&self, key: &str) -> Option<T> {
         self.properties.get(key)

--- a/lib/tests/nodes.rs
+++ b/lib/tests/nodes.rs
@@ -1,3 +1,5 @@
+use std::vec;
+
 use neo4rs::*;
 
 mod container;
@@ -19,10 +21,12 @@ async fn nodes() {
     while let Ok(Some(row)) = result.next().await {
         let node: Node = row.get("friend").unwrap();
         let id = node.id();
+        let keys = node.keys();
         let labels = node.labels();
         let name: String = node.get("name").unwrap();
         assert_eq!(name, "Mr Mark");
         assert_eq!(labels, vec!["Person"]);
+        assert_eq!(keys, vec![String::from("name")]);
         assert!(id >= 0);
     }
 }


### PR DESCRIPTION
This provides a `keys()` method for Nodes and Relations. 

This makes it simpler to get the keys of a node/relation and iterate over them to extract the node/relation data if you don't know the key names ahead of time. 

**Usage**
```rust

let node = .... // however you got node
for key in node.keys() {
    // do something with the key or value
}


```