### PR TITLE
add Query::has_param_key

### DIFF
--- a/lib/src/query.rs
+++ b/lib/src/query.rs
@@ -100,6 +100,6 @@ mod tests {
         assert_eq!(q.params.get::<i64>("age").unwrap(), 42);
 
         assert!(q.has_param_key("name"));
-        assert!(q.has_param_key("country") == false);
+        assert!(!q.has_param_key("country"));
     }
 }

--- a/lib/src/query.rs
+++ b/lib/src/query.rs
@@ -39,6 +39,10 @@ impl Query {
         self
     }
 
+    pub fn has_param_key(&self, key: &str) -> bool {
+        self.params.value.contains_key(&key.into())
+    }
+
     pub(crate) async fn run(
         self,
         config: &Config,
@@ -94,5 +98,8 @@ mod tests {
             String::from("Frobniscante")
         );
         assert_eq!(q.params.get::<i64>("age").unwrap(), 42);
+
+        assert!(q.has_param_key("name"));
+        assert!(q.has_param_key("country") == false);
     }
 }

--- a/lib/src/query.rs
+++ b/lib/src/query.rs
@@ -40,7 +40,7 @@ impl Query {
     }
 
     pub fn has_param_key(&self, key: &str) -> bool {
-        self.params.value.contains_key(&key.into())
+        self.params.value.contains_key(key)
     }
 
     pub(crate) async fn run(


### PR DESCRIPTION
This is to expose the ability to warn, etc. if overwriting an existing param key.