### PR TITLE
Implement From<Option> for BoltType

### DIFF
--- a/lib/src/convert.rs
+++ b/lib/src/convert.rs
@@ -366,6 +366,15 @@ impl From<&str> for BoltType {
     }
 }
 
+impl<T: Into<BoltType>> From<Option<T>> for BoltType {
+    fn from(value: Option<T>) -> Self {
+        match value {
+            Some(v) => v.into(),
+            None => BoltType::Null(BoltNull),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -422,5 +431,23 @@ mod tests {
                 ],
             })
         );
+    }
+
+    #[test]
+    fn convert_from_option() {
+        let value: Option<Vec<i64>> = Some(vec![42, 1337]);
+        let value: BoltType = value.into();
+        assert_eq!(
+            value,
+            BoltType::List(BoltList {
+                value: vec![
+                    BoltType::Integer(BoltInteger::new(42)),
+                    BoltType::Integer(BoltInteger::new(1337)),
+                ],
+            })
+        );
+        let value: Option<Vec<i64>> = None;
+        let value: BoltType = value.into();
+        assert_eq!(value, BoltType::Null(BoltNull));
     }
 }


### PR DESCRIPTION
Query strings that use a placeholder `$foo` for an `Option<Into<BoltType>>` cannot be constructed without first knowing if the option is `None`. This is bothersome because basic query strings for a struct can be determined without `self`, but filling in query params requires a `self`.

This PR associates a query parameter  of  `None` to mean `BoltType::Null(BoltNull)`. 

Does this change semantics? Before this, removing a property on an entity could be done via `SET n.prop = null`, but now it could be done with `SET n.prop = $prop`. It allows a kind of silly Option<Vec<Option<A>>> as a type. 

Will `serde` support take care of this (there's a draft PR)?