### PR TITLE
Improve API for RowStream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 container-license-acceptance.txt
+Session.vim

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -34,13 +34,13 @@ webpki-roots = "0.23.0"
 
 [dev-dependencies]
 lenient_semver = { version = "0.4.2", default_features = false, features = ["version_lite"] }
-pretty_env_logger = "0.4.0"
-testcontainers = "0.14.0"
 neo4j_testcontainers = "0.2.0"
-uuid = { version = "1.0.0", features = ["v4"] }
+pretty_env_logger = "0.4.0"
 serde = { version = "1.0.185", features = ["derive"] }
 serde_bytes = "0.11.0"
 serde_json = "1.0.0"
 serde_with = "3.0.0"
 tap = "1.0.1"
+testcontainers = "0.14.0"
 time = { version = "0.3.0", features = ["serde"] }
+uuid = { version = "1.0.0", features = ["v4"] }

--- a/lib/src/errors.rs
+++ b/lib/src/errors.rs
@@ -1,3 +1,5 @@
+use crate::DeError;
+
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]
@@ -57,7 +59,7 @@ pub enum Error {
     InvalidTypeMarker(String),
 
     #[error("{0}")]
-    DeserializationError(String),
+    DeserializationError(DeError),
 }
 
 impl std::convert::From<deadpool::managed::PoolError<Error>> for Error {

--- a/lib/src/types/string.rs
+++ b/lib/src/types/string.rs
@@ -2,6 +2,7 @@ use crate::{
     errors::{Error, Result},
     types::BoltWireFormat,
     version::Version,
+    DeError,
 };
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::{borrow::Borrow, str::from_utf8};
@@ -81,7 +82,7 @@ impl BoltWireFormat for BoltString {
         let bytes = input.split_to(length);
         match from_utf8(&bytes) {
             Ok(t) => Ok(t.into()),
-            Err(e) => Err(Error::DeserializationError(e.to_string())),
+            Err(e) => Err(Error::DeserializationError(DeError::Other(e.to_string()))),
         }
     }
 


### PR DESCRIPTION
Adding a few methods to the RowStream that allow it to be treated as a
`futures::Stream`, optionally with serde integration.

Also, we try to parse a single column of a row if parsing the row as a whole fails.
