### PR TITLE
breaking! Remove internal mutex boxing of connections

### DIFF
--- a/lib/include/rollback_a_transaction.rs
+++ b/lib/include/rollback_a_transaction.rs
@@ -1,5 +1,5 @@
 { 
-    let txn = graph.start_txn().await.unwrap();
+    let mut txn = graph.start_txn().await.unwrap();
     let id = uuid::Uuid::new_v4().to_string();
     // create a node
     txn.run(query("CREATE (p:Person {id: $id})").param("id", id.clone()))

--- a/lib/include/streams_within_a_transaction.rs
+++ b/lib/include/streams_within_a_transaction.rs
@@ -1,6 +1,6 @@
 { 
     let name = uuid::Uuid::new_v4().to_string();
-    let txn = graph.start_txn().await.unwrap();
+    let mut txn = graph.start_txn().await.unwrap();
 
     #[derive(serde::Deserialize)]
     struct Person {
@@ -19,21 +19,21 @@
         .execute(query("MATCH (p {name: $name}) RETURN p").param("name", name.clone()))
         .await
         .unwrap();
-    let row = stream_one.next().await.unwrap().unwrap();
+    let row = stream_one.next(txn.handle()).await.unwrap().unwrap();
     assert_eq!(row.to::<Person>().unwrap().name, name);
 
     //start stream_two
     let mut stream_two = txn.execute(query("RETURN 1")).await.unwrap();
-    let row = stream_two.next().await.unwrap().unwrap();
+    let row = stream_two.next(txn.handle()).await.unwrap().unwrap();
     assert_eq!(row.to::<i64>().unwrap(), 1);
 
     //stream_one is still active here
-    let row = stream_one.next().await.unwrap().unwrap();
+    let row = stream_one.next(txn.handle()).await.unwrap().unwrap();
     assert_eq!(row.to::<Person>().unwrap().name, name);
 
     //stream_one completes
-    assert!(stream_one.next().await.unwrap().is_none());
+    assert!(stream_one.next(txn.handle()).await.unwrap().is_none());
     //stream_two completes
-    assert!(stream_two.next().await.unwrap().is_none());
+    assert!(stream_two.next(txn.handle()).await.unwrap().is_none());
     txn.commit().await.unwrap();
 }

--- a/lib/include/transactions.rs
+++ b/lib/include/transactions.rs
@@ -1,5 +1,5 @@
 {
-    let txn = graph.start_txn().await.unwrap();
+    let mut txn = graph.start_txn().await.unwrap();
     let id = uuid::Uuid::new_v4().to_string();
     let result = txn
         .run_queries(vec![

--- a/lib/include/txn_vs_graph.rs
+++ b/lib/include/txn_vs_graph.rs
@@ -1,5 +1,5 @@
 { 
-    let txn = graph.start_txn().await.unwrap();
+    let mut txn = graph.start_txn().await.unwrap();
     let id = uuid::Uuid::new_v4().to_string();
     txn.run(query("CREATE (p:Person {id: $id})").param("id", id.clone()))
         .await

--- a/lib/src/messages/commit.rs
+++ b/lib/src/messages/commit.rs
@@ -10,6 +10,12 @@ impl Commit {
     }
 }
 
+impl Default for Commit {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/src/messages/reset.rs
+++ b/lib/src/messages/reset.rs
@@ -10,6 +10,12 @@ impl Reset {
     }
 }
 
+impl Default for Reset {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/src/messages/rollback.rs
+++ b/lib/src/messages/rollback.rs
@@ -10,6 +10,12 @@ impl Rollback {
     }
 }
 
+impl Default for Rollback {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/src/stream.rs
+++ b/lib/src/stream.rs
@@ -3,20 +3,17 @@ use crate::{
     messages::{BoltRequest, BoltResponse},
     pool::ManagedConnection,
     row::Row,
+    txn::TransactionHandle,
     types::BoltList,
     DeError,
 };
 use futures::{stream::try_unfold, TryStream};
 use serde::de::DeserializeOwned;
 use std::collections::VecDeque;
-use std::sync::Arc;
-use tokio::sync::Mutex;
 
-/// An abstraction over a stream of rows, this is returned as a result of [`crate::Graph::execute`] or
-/// [`crate::Txn::execute`] operations
+/// An abstraction over a stream of rows, this is returned as a result of [`crate::Txn::execute`].
 ///
-/// A stream will contain a connection from the connection pool which will be released to the pool
-/// when the stream is dropped.
+/// A stream needs a running transaction to be consumed.
 #[must_use = "Results must be streamed through with `next` in order to execute the query"]
 pub struct RowStream {
     qid: i64,
@@ -24,60 +21,66 @@ pub struct RowStream {
     state: State,
     fetch_size: usize,
     buffer: VecDeque<Row>,
-    connection: Arc<Mutex<ManagedConnection>>,
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
-enum State {
-    Ready,
-    Streaming,
-    Buffered,
-    Complete,
+/// An abstraction over a stream of rows, this is returned as a result of [`crate::Graph::execute`].
+///
+/// A stream will contain a connection from the connection pool which will be released to the pool
+/// when the stream is dropped.
+#[must_use = "Results must be streamed through with `next` in order to execute the query"]
+pub struct DetachedRowStream {
+    stream: RowStream,
+    connection: ManagedConnection,
 }
 
 impl RowStream {
-    pub(crate) fn new(
-        qid: i64,
-        fields: BoltList,
-        fetch_size: usize,
-        connection: Arc<Mutex<ManagedConnection>>,
-    ) -> RowStream {
+    pub(crate) fn new(qid: i64, fields: BoltList, fetch_size: usize) -> Self {
         RowStream {
             qid,
             fields,
-            connection,
             fetch_size,
             state: State::Ready,
             buffer: VecDeque::with_capacity(fetch_size),
         }
     }
+}
 
+impl DetachedRowStream {
+    pub(crate) fn new(stream: RowStream, connection: ManagedConnection) -> Self {
+        DetachedRowStream { stream, connection }
+    }
+}
+
+impl RowStream {
     /// A call to next() will return a row from an internal buffer if the buffer has any entries,
-    /// if the buffer is empty and the server has more rows left to consume, then a new batch of rows are fetched from the server (using the
-    /// fetch_size value configured see [`crate::ConfigBuilder::fetch_size`])
-    pub async fn next(&mut self) -> Result<Option<Row>> {
-        let mut connection = self.connection.lock().await;
+    /// if the buffer is empty and the server has more rows left to consume, then a new batch of rows
+    /// are fetched from the server (using the fetch_size value configured see [`crate::ConfigBuilder::fetch_size`])
+    pub async fn next(&mut self, mut handle: impl TransactionHandle) -> Result<Option<Row>> {
         loop {
             match self.state {
                 State::Ready => {
                     let pull = BoltRequest::pull(self.fetch_size, self.qid);
+                    let connection = handle.connection();
                     connection.send(pull).await?;
                     self.state = State::Streaming;
                 }
-                State::Streaming => match connection.recv().await {
-                    Ok(BoltResponse::Success(s)) => {
-                        if s.get("has_more").unwrap_or(false) {
-                            self.state = State::Buffered;
-                        } else {
-                            self.state = State::Complete;
+                State::Streaming => {
+                    let connection = handle.connection();
+                    match connection.recv().await {
+                        Ok(BoltResponse::Success(s)) => {
+                            if s.get("has_more").unwrap_or(false) {
+                                self.state = State::Buffered;
+                            } else {
+                                self.state = State::Complete;
+                            }
                         }
+                        Ok(BoltResponse::Record(record)) => {
+                            let row = Row::new(self.fields.clone(), record.data);
+                            self.buffer.push_back(row);
+                        }
+                        msg => return Err(unexpected(msg, "PULL")),
                     }
-                    Ok(BoltResponse::Record(record)) => {
-                        let row = Row::new(self.fields.clone(), record.data);
-                        self.buffer.push_back(row);
-                    }
-                    msg => return Err(unexpected(msg, "PULL")),
-                },
+                }
                 State::Buffered => {
                     if !self.buffer.is_empty() {
                         return Ok(self.buffer.pop_front());
@@ -93,10 +96,13 @@ impl RowStream {
 
     /// Turns this RowStream into a [`futures::stream::TryStream`] where
     /// every element is a [`crate::row::Row`].
-    pub fn into_stream(self) -> impl TryStream<Ok = Row, Error = Error> {
-        try_unfold(self, |mut stream| async move {
-            match stream.next().await {
-                Ok(Some(row)) => Ok(Some((row, stream))),
+    pub fn into_stream(
+        self,
+        handle: impl TransactionHandle,
+    ) -> impl TryStream<Ok = Row, Error = Error> {
+        try_unfold((self, handle), |(mut stream, mut hd)| async move {
+            match stream.next(&mut hd).await {
+                Ok(Some(row)) => Ok(Some((row, (stream, hd)))),
                 Ok(None) => Ok(None),
                 Err(e) => Err(e),
             }
@@ -105,8 +111,65 @@ impl RowStream {
 
     /// Turns this RowStream into a [`futures::stream::TryStream`] where
     /// every row is converted into a `T` by calling [`crate::row::Row::to`].
+    pub fn into_stream_as<T: DeserializeOwned>(
+        self,
+        handle: impl TransactionHandle,
+    ) -> impl TryStream<Ok = T, Error = Error> {
+        self.into_stream_de(handle, |row| row.to::<T>())
+    }
+
+    /// Turns this RowStream into a [`futures::stream::TryStream`] where
+    /// the value at the given column is converted into a `T`
+    /// by calling [`crate::row::Row::get`].
+    pub fn column_into_stream<'db, T: DeserializeOwned + 'db>(
+        self,
+        handle: impl TransactionHandle + 'db,
+        column: &'db str,
+    ) -> impl TryStream<Ok = T, Error = Error> + 'db {
+        self.into_stream_de(handle, move |row| row.get::<T>(column))
+    }
+
+    fn into_stream_de<T: DeserializeOwned>(
+        self,
+        handle: impl TransactionHandle,
+        deser: impl Fn(Row) -> Result<T, DeError>,
+    ) -> impl TryStream<Ok = T, Error = Error> {
+        try_unfold(
+            (self, handle, deser),
+            |(mut stream, mut hd, de)| async move {
+                match stream.next(&mut hd).await {
+                    Ok(Some(row)) => match de(row) {
+                        Ok(res) => Ok(Some((res, (stream, hd, de)))),
+                        Err(e) => Err(Error::DeserializationError(e)),
+                    },
+                    Ok(None) => Ok(None),
+                    Err(e) => Err(e),
+                }
+            },
+        )
+    }
+}
+
+impl DetachedRowStream {
+    /// A call to next() will return a row from an internal buffer if the buffer has any entries,
+    /// if the buffer is empty and the server has more rows left to consume, then a new batch of rows are fetched from the server (using the
+    /// fetch_size value configured see [`crate::ConfigBuilder::fetch_size`])
+    pub async fn next(&mut self) -> Result<Option<Row>> {
+        self.stream.next(&mut self.connection).await
+    }
+
+    /// Turns this RowStream into a [`futures::stream::TryStream`] where
+    /// every element is a [`crate::row::Row`].
+    pub fn into_stream(self) -> impl TryStream<Ok = Row, Error = Error> {
+        self.stream.into_stream(self.connection)
+    }
+
+    /// Turns this RowStream into a [`futures::stream::TryStream`] where
+    /// every row is converted into a `T` by calling [`crate::row::Row::to`].
+    /// If the conversion fails and the result stream has exactly one column,
+    /// that single value will be converted by calling [`crate::BoltType::to`].
     pub fn into_stream_as<T: DeserializeOwned>(self) -> impl TryStream<Ok = T, Error = Error> {
-        self.into_stream_de(|row| row.to::<T>())
+        self.stream.into_stream_as(self.connection)
     }
 
     /// Turns this RowStream into a [`futures::stream::TryStream`] where
@@ -116,22 +179,14 @@ impl RowStream {
         self,
         column: &'db str,
     ) -> impl TryStream<Ok = T, Error = Error> + 'db {
-        self.into_stream_de(move |row| row.get::<T>(column))
+        self.stream.column_into_stream(self.connection, column)
     }
+}
 
-    fn into_stream_de<T: DeserializeOwned>(
-        self,
-        deser: impl Fn(Row) -> Result<T, DeError>,
-    ) -> impl TryStream<Ok = T, Error = Error> {
-        try_unfold((self, deser), |(mut stream, de)| async move {
-            match stream.next().await {
-                Ok(Some(row)) => match de(row) {
-                    Ok(res) => Ok(Some((res, (stream, de)))),
-                    Err(e) => Err(Error::DeserializationError(e)),
-                },
-                Ok(None) => Ok(None),
-                Err(e) => Err(e),
-            }
-        })
-    }
+#[derive(Copy, Clone, PartialEq, Debug)]
+enum State {
+    Ready,
+    Streaming,
+    Buffered,
+    Complete,
 }

--- a/lib/tests/txn_change_db.rs
+++ b/lib/tests/txn_change_db.rs
@@ -36,12 +36,11 @@ async fn txn_changes_db() {
         name: String,
     }
 
-    let txn = graph.start_txn().await.unwrap();
-
+    let mut txn = graph.start_txn().await.unwrap();
     let databases = txn.execute(query("SHOW DATABASES")).await.unwrap();
 
     let mut names = databases
-        .into_stream_as::<Database>()
+        .into_stream_as::<Database>(txn.handle())
         .map_ok(|db| db.name)
         .try_collect::<Vec<_>>()
         .await


### PR DESCRIPTION
Connections are no longer always wrapped in an Arc<Mutex<>>.

This actually introduces a number of breaking changes:
- `Graph::execute` returns a `DetachedRowStream` instead of a `RowStream` (name pending)
  The API is identical, but it's a different type
- `Txn::execute` continues to return a `RowStream`, but its API changed:
  - `RowStream::next` required a `TransactionHandle`, which can be obtained by calling `Txn::handle`
  - This method is defined as `fn handle(&mut self)`, which means that the synchronization of concurrent query streams within a single transactions must now be handled by the user
  - The same is true for all other methods consuming the `RowStream`
- `Txn` methods now require `&mut self` instead of `&self`
