### PR TITLE
Be more flexible in what is accepted for run_queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Only the latest 5.x version is supported, following the [Neo4j Version support p
 
 ## Example
 
-```rust    
+```rust
     // concurrent queries
     let uri = "127.0.0.1:7687";
     let user = "neo4j";
@@ -28,27 +28,26 @@ Only the latest 5.x version is supported, following the [Neo4j Version support p
         let graph = graph.clone();
         tokio::spawn(async move {
             let mut result = graph.execute(
-	       query("MATCH (p:Person {name: $name}) RETURN p").param("name", "Mark")
-	    ).await.unwrap();
+           query("MATCH (p:Person {name: $name}) RETURN p").param("name", "Mark")
+        ).await.unwrap();
             while let Ok(Some(row)) = result.next().await {
-        	let node: Node = row.get("p").unwrap();
-        	let name: String = node.get("name").unwrap();
+            let node: Node = row.get("p").unwrap();
+            let name: String = node.get("name").unwrap();
                 println!("{}", name);
             }
         });
     }
-    
+
     //Transactions
     let mut txn = graph.start_txn().await.unwrap();
-    txn.run_queries(vec![
-        query("CREATE (p:Person {name: 'mark'})"),
-        query("CREATE (p:Person {name: 'jake'})"),
-        query("CREATE (p:Person {name: 'luke'})"),
+    txn.run_queries([
+        "CREATE (p:Person {name: 'mark'})",
+        "CREATE (p:Person {name: 'jake'})",
+        "CREATE (p:Person {name: 'luke'})",
     ])
     .await
     .unwrap();
     txn.commit().await.unwrap(); //or txn.rollback().await.unwrap();
-    
 ```
 
 ## MSRV

--- a/lib/include/streams_within_a_transaction.rs
+++ b/lib/include/streams_within_a_transaction.rs
@@ -7,7 +7,7 @@
         name: String,
     }
 
-    txn.run_queries(vec![
+    txn.run_queries([
         query("CREATE (p { name: $name })").param("name", name.clone()),
         query("CREATE (p { name: $name })").param("name", name.clone()),
     ])

--- a/lib/include/transactions.rs
+++ b/lib/include/transactions.rs
@@ -2,7 +2,7 @@
     let mut txn = graph.start_txn().await.unwrap();
     let id = uuid::Uuid::new_v4().to_string();
     let result = txn
-        .run_queries(vec![
+        .run_queries([
             query("CREATE (p:Person {id: $id})").param("id", id.clone()),
             query("CREATE (p:Person {id: $id})").param("id", id.clone()),
         ])

--- a/lib/src/query.rs
+++ b/lib/src/query.rs
@@ -81,6 +81,18 @@ impl Query {
     }
 }
 
+impl From<String> for Query {
+    fn from(query: String) -> Self {
+        Query::new(query)
+    }
+}
+
+impl From<&str> for Query {
+    fn from(query: &str) -> Self {
+        Query::new(query.to_owned())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/src/txn.rs
+++ b/lib/src/txn.rs
@@ -34,9 +34,12 @@ impl Txn {
     }
 
     /// Runs multiple queries one after the other in the same connection
-    pub async fn run_queries(&mut self, queries: Vec<Query>) -> Result<()> {
-        for query in queries.into_iter() {
-            self.run(query).await?;
+    pub async fn run_queries<Q: Into<Query>>(
+        &mut self,
+        queries: impl IntoIterator<Item = Q>,
+    ) -> Result<()> {
+        for query in queries {
+            self.run(query.into()).await?;
         }
         Ok(())
     }


### PR DESCRIPTION
Allows to use any `IntoIter` with any `Into<Query>`.

