### PR TITLE
Only store cheap/rc cloneable fields inside of Graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Only the latest 5.x version is supported, following the [Neo4j Version support p
     let uri = "127.0.0.1:7687";
     let user = "neo4j";
     let pass = "neo";
-    let graph = Arc::new(Graph::new(&uri, user, pass).await.unwrap());
+    let graph = Graph::new(&uri, user, pass).await.unwrap();
     for _ in 1..=42 {
         let graph = graph.clone();
         tokio::spawn(async move {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -22,7 +22,7 @@
 //!    let pass = "neo";
 //!    let id = uuid::Uuid::new_v4().to_string();
 //!
-//!    let graph = std::sync::Arc::new(Graph::new(uri, user, pass).await.unwrap());
+//!    let graph = Graph::new(uri, user, pass).await.unwrap();
 //!
 #![doc = include_str!("../include/example.rs")]
 //! }
@@ -435,7 +435,7 @@ mod txn;
 mod types;
 mod version;
 
-pub use crate::config::{Config, ConfigBuilder};
+pub use crate::config::{Config, ConfigBuilder, Database};
 pub use crate::errors::*;
 pub use crate::graph::{query, Graph};
 pub use crate::query::Query;

--- a/lib/src/txn.rs
+++ b/lib/src/txn.rs
@@ -1,4 +1,5 @@
 use crate::{
+    config::Database,
     errors::{unexpected, Result},
     messages::{BoltRequest, BoltResponse},
     pool::ManagedConnection,
@@ -11,21 +12,21 @@ use crate::{
 /// When a transation is started, a dedicated connection is resered and moved into the handle which
 /// will be released to the connection pool when the [`Txn`] handle is dropped.
 pub struct Txn {
-    db: String,
+    db: Database,
     fetch_size: usize,
     connection: ManagedConnection,
 }
 
 impl Txn {
     pub(crate) async fn new(
-        db: &str,
+        db: Database,
         fetch_size: usize,
         mut connection: ManagedConnection,
     ) -> Result<Self> {
-        let begin = BoltRequest::begin(db);
+        let begin = BoltRequest::begin(&db);
         match connection.send_recv(begin).await? {
             BoltResponse::Success(_) => Ok(Txn {
-                db: db.to_owned(),
+                db,
                 fetch_size,
                 connection,
             }),

--- a/lib/tests/container.rs
+++ b/lib/tests/container.rs
@@ -3,7 +3,7 @@ use neo4j_testcontainers::{Neo4j, Neo4jImage};
 use neo4rs::{ConfigBuilder, Graph};
 use testcontainers::{clients::Cli, Container};
 
-use std::{error::Error, sync::Arc};
+use std::error::Error;
 
 #[allow(dead_code)]
 #[derive(Default)]
@@ -39,7 +39,7 @@ impl Neo4jContainerBuilder {
 }
 
 pub struct Neo4jContainer {
-    graph: Arc<Graph>,
+    graph: Graph,
     version: String,
     _container: Option<Container<'static, Neo4jImage>>,
 }
@@ -82,7 +82,7 @@ impl Neo4jContainer {
         })
     }
 
-    pub fn graph(&self) -> Arc<Graph> {
+    pub fn graph(&self) -> Graph {
         self.graph.clone()
     }
 
@@ -156,7 +156,7 @@ impl Neo4jContainer {
         TestConnection { uri, auth, version }
     }
 
-    async fn connect(config: ConfigBuilder, uri: String, auth: &TestAuth) -> Arc<Graph> {
+    async fn connect(config: ConfigBuilder, uri: String, auth: &TestAuth) -> Graph {
         let config = config
             .uri(uri)
             .user(&auth.user)
@@ -164,9 +164,7 @@ impl Neo4jContainer {
             .build()
             .unwrap();
 
-        let graph = Graph::connect(config).await.unwrap();
-
-        Arc::new(graph)
+        Graph::connect(config).await.unwrap()
     }
 }
 


### PR DESCRIPTION
- deadpool::Pool are "cheap to clone because of reference counting" according to their doc.
- We only store the config values we actually need after having created the pool and use `Arc<str>` for the string to also get a cheap clone
- Now we can make `Graph: Clone`
