### PR TITLE
Support optional uuid type conversions (behind feature flag)

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { version = "1.5.0", features = ["full"] }
 tokio-rustls = "0.24.0"
 url = "2.0.0"
 webpki-roots = "0.23.0"
+uuid = { version = "1.6.0", optional = true }
 
 [dev-dependencies]
 lenient_semver = { version = "0.4.2", default_features = false, features = ["version_lite"] }
@@ -44,3 +45,7 @@ tap = "1.0.1"
 testcontainers = "0.14.0"
 time = { version = "0.3.0", features = ["serde"] }
 uuid = { version = "1.0.0", features = ["v4"] }
+
+[features]
+default = []
+uuid = ["dep:uuid"]


### PR DESCRIPTION
Uuids are at least a second class citizen in neo4j, so it would be nice to directly (de)serialize them in neo4rs!

I put it behind a feature flag in case anyone doesn't want an extra dependency.