### PR TITLE
Implement TryInto<serde_json::Value>, with optional `json` feature

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,6 +16,9 @@ categories = ["database", "network-programming", "asynchronous"]
 rust-version = "1.63"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+json = ["serde_json"]
+
 [dependencies]
 async-trait = "0.1.0"
 bytes = { version = "1.5.0", features = ["serde"] }
@@ -32,6 +35,7 @@ neo4rs-macros = { version = "0.3.0", path = "../macros" }
 paste = "1.0.0"
 pin-project-lite = "0.2.9"
 serde = { version = "1.0.185", features = ["derive"] } # TODO: eliminate derive
+serde_json = { version = "1.0.0", optional = true }
 thiserror = "1.0.7"
 tokio = { version = "1.5.0", features = ["full"] }
 tokio-rustls = "0.24.0"


### PR DESCRIPTION
Implementing `TryInto` let's users do:
```rust
.param("inputs", neo4rs::BoltType::try_from(serde_json::to_value(some_serializable_value)?)?)
```

It would be nice to avoid explicitly calling `try_from` here, but `param` doesn't return a `Result` so... I don't want to introduce breaking changes