### PR TITLE
Use server default db over hardcoded default db

### DIFF
--- a/lib/src/messages.rs
+++ b/lib/src/messages.rs
@@ -129,8 +129,8 @@ impl BoltRequest {
         BoltRequest::Hello(hello::Hello::new(data))
     }
 
-    pub fn run(db: &str, query: &str, params: BoltMap) -> BoltRequest {
-        BoltRequest::Run(Run::new(db.into(), query.into(), params))
+    pub fn run(db: Option<&str>, query: &str, params: BoltMap) -> BoltRequest {
+        BoltRequest::Run(Run::new(db.map(Into::into), query.into(), params))
     }
 
     pub fn pull(n: usize, qid: i64) -> BoltRequest {
@@ -145,8 +145,9 @@ impl BoltRequest {
         BoltRequest::Discard(discard::Discard::default())
     }
 
-    pub fn begin(db: &str) -> BoltRequest {
-        let begin = Begin::new([("db".into(), db.into())].into_iter().collect());
+    pub fn begin(db: Option<&str>) -> BoltRequest {
+        let extra = db.into_iter().map(|db| ("db".into(), db.into())).collect();
+        let begin = Begin::new(extra);
         BoltRequest::Begin(begin)
     }
 

--- a/lib/src/messages/run.rs
+++ b/lib/src/messages/run.rs
@@ -10,12 +10,13 @@ pub struct Run {
 }
 
 impl Run {
-    pub fn new(db: BoltString, query: BoltString, parameters: BoltMap) -> Run {
+    pub fn new(db: Option<BoltString>, query: BoltString, parameters: BoltMap) -> Run {
         Run {
             query,
             parameters,
-            extra: vec![("db".into(), BoltType::String(db))]
+            extra: db
                 .into_iter()
+                .map(|db| ("db".into(), BoltType::String(db)))
                 .collect(),
         }
     }
@@ -31,7 +32,7 @@ mod tests {
     #[test]
     fn should_serialize_run() {
         let run = Run::new(
-            "test".into(),
+            Some("test".into()),
             "query".into(),
             vec![("k".into(), "v".into())].into_iter().collect(),
         );
@@ -69,7 +70,7 @@ mod tests {
 
     #[test]
     fn should_serialize_run_with_no_params() {
-        let run = Run::new("".into(), "query".into(), BoltMap::default());
+        let run = Run::new(None, "query".into(), BoltMap::default());
 
         let bytes: Bytes = run.into_bytes(Version::V4_1).unwrap();
 
@@ -85,11 +86,7 @@ mod tests {
                 b'r',
                 b'y',
                 map::TINY,
-                map::TINY | 1,
-                string::TINY | 2,
-                b'd',
-                b'b',
-                string::TINY,
+                map::TINY,
             ])
         );
     }

--- a/lib/src/query.rs
+++ b/lib/src/query.rs
@@ -45,7 +45,11 @@ impl Query {
         self.params.value.contains_key(key)
     }
 
-    pub(crate) async fn run(self, db: &str, connection: &mut ManagedConnection) -> Result<()> {
+    pub(crate) async fn run(
+        self,
+        db: Option<&str>,
+        connection: &mut ManagedConnection,
+    ) -> Result<()> {
         let request = BoltRequest::run(db, &self.query, self.params);
         Self::try_run(request, connection)
             .await
@@ -54,7 +58,7 @@ impl Query {
 
     pub(crate) async fn run_retryable(
         &self,
-        db: &str,
+        db: Option<&str>,
         connection: &mut ManagedConnection,
     ) -> QueryResult<()> {
         let request = BoltRequest::run(db, &self.query, self.params.clone());
@@ -63,7 +67,7 @@ impl Query {
 
     pub(crate) async fn execute_retryable(
         &self,
-        db: &str,
+        db: Option<&str>,
         fetch_size: usize,
         mut connection: ManagedConnection,
     ) -> QueryResult<DetachedRowStream> {
@@ -75,7 +79,7 @@ impl Query {
 
     pub(crate) async fn execute_mut<'conn>(
         self,
-        db: &str,
+        db: Option<&str>,
         fetch_size: usize,
         connection: &'conn mut ManagedConnection,
     ) -> Result<RowStream> {

--- a/lib/tests/container.rs
+++ b/lib/tests/container.rs
@@ -1,6 +1,6 @@
 use lenient_semver::Version;
 use neo4rs::{ConfigBuilder, Graph};
-use testcontainers::{runners::SyncRunner, Container, ImageExt};
+use testcontainers::{runners::SyncRunner, Container, ContainerRequest, ImageExt};
 use testcontainers_modules::neo4j::{Neo4j, Neo4jImage};
 
 use std::{error::Error, io::BufRead as _};
@@ -10,6 +10,7 @@ use std::{error::Error, io::BufRead as _};
 pub struct Neo4jContainerBuilder {
     enterprise: bool,
     config: ConfigBuilder,
+    env: Vec<(String, String)>,
 }
 
 #[allow(dead_code)]
@@ -23,18 +24,32 @@ impl Neo4jContainerBuilder {
         self
     }
 
-    pub fn with_config(mut self, config: ConfigBuilder) -> Self {
+    pub fn with_driver_config(mut self, config: ConfigBuilder) -> Self {
         self.config = config;
         self
     }
 
-    pub fn modify_config(mut self, block: impl FnOnce(ConfigBuilder) -> ConfigBuilder) -> Self {
+    pub fn modify_driver_config(
+        mut self,
+        block: impl FnOnce(ConfigBuilder) -> ConfigBuilder,
+    ) -> Self {
         self.config = block(self.config);
         self
     }
 
+    pub fn add_env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.push((key.into(), value.into()));
+        self
+    }
+
+    pub fn with_server_config(self, key: &str, value: impl Into<String>) -> Self {
+        let key = format!("NEO4J_{}", key.replace('_', "__").replace('.', "_"));
+        self.add_env(key, value)
+    }
+
     pub async fn start(self) -> Result<Neo4jContainer, Box<dyn Error + Send + Sync + 'static>> {
-        Neo4jContainer::from_config_and_edition(self.config, self.enterprise).await
+        Neo4jContainer::from_config_and_edition_and_env(self.config, self.enterprise, self.env)
+            .await
     }
 }
 
@@ -58,6 +73,20 @@ impl Neo4jContainer {
         config: ConfigBuilder,
         enterprise_edition: bool,
     ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        Self::from_config_and_edition_and_env::<_, String, String>(config, enterprise_edition, [])
+            .await
+    }
+
+    pub async fn from_config_and_edition_and_env<I, K, V>(
+        config: ConfigBuilder,
+        enterprise_edition: bool,
+        env_vars: I,
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
         let _ = pretty_env_logger::try_init();
 
         let server = Self::server_from_env();
@@ -65,7 +94,11 @@ impl Neo4jContainer {
 
         let (uri, _container) = match server {
             TestServer::TestContainer => {
-                let (uri, container) = Self::create_testcontainer(&connection, enterprise_edition)?;
+                let (uri, container) = Self::create_testcontainer(
+                    &connection,
+                    enterprise_edition,
+                    env_vars.into_iter().map(|(k, v)| (k.into(), v.into())),
+                )?;
                 (uri, Some(container))
             }
             TestServer::External(uri) | TestServer::Aura(uri) => (uri, None),
@@ -107,10 +140,30 @@ impl Neo4jContainer {
             .unwrap_or(TestServer::TestContainer)
     }
 
-    fn create_testcontainer(
+    fn create_testcontainer<I>(
         connection: &TestConnection,
         enterprise: bool,
-    ) -> Result<(String, Container<Neo4jImage>), Box<dyn Error + Send + Sync + 'static>> {
+        env_vars: I,
+    ) -> Result<(String, Container<Neo4jImage>), Box<dyn Error + Send + Sync + 'static>>
+    where
+        I: Iterator<Item = (String, String)>,
+    {
+        let container = Self::create_testcontainer_image(connection, enterprise, env_vars)?;
+        let container = container.start()?;
+
+        let uri = format!("bolt://127.0.0.1:{}", container.image().bolt_port_ipv4()?);
+
+        Ok((uri, container))
+    }
+
+    fn create_testcontainer_image<I>(
+        connection: &TestConnection,
+        enterprise: bool,
+        env_vars: I,
+    ) -> Result<ContainerRequest<Neo4jImage>, Box<dyn Error + Send + Sync + 'static>>
+    where
+        I: Iterator<Item = (String, String)>,
+    {
         let image = Neo4j::new()
             .with_user(connection.auth.user.to_owned())
             .with_password(connection.auth.pass.to_owned());
@@ -147,17 +200,17 @@ impl Neo4jContainer {
                 .into());
             }
 
-            image
-                .with_version(version)
-                .with_env_var("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-                .start()?
+            env_vars.fold(
+                image
+                    .with_version(version)
+                    .with_env_var("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes"),
+                |i, (k, v)| i.with_env_var(k, v),
+            )
         } else {
-            image.with_version(connection.version.to_owned()).start()?
+            image.with_version(connection.version.to_owned()).into()
         };
 
-        let uri = format!("bolt://127.0.0.1:{}", container.image().bolt_port_ipv4()?);
-
-        Ok((uri, container))
+        Ok(container)
     }
 
     fn create_test_endpoint(use_aura: bool) -> TestConnection {

--- a/lib/tests/txn_change_db.rs
+++ b/lib/tests/txn_change_db.rs
@@ -7,7 +7,7 @@ mod container;
 #[tokio::test]
 async fn txn_changes_db() {
     let neo4j = match container::Neo4jContainerBuilder::new()
-        .modify_config(|c| c.db("deebee"))
+        .modify_driver_config(|c| c.db("deebee"))
         .with_enterprise_edition()
         .start()
         .await

--- a/lib/tests/txn_change_db.rs
+++ b/lib/tests/txn_change_db.rs
@@ -14,8 +14,12 @@ async fn txn_changes_db() {
     {
         Ok(n) => n,
         Err(e) => {
-            eprintln!("Skipping test: {}", e);
-            return;
+            if e.to_string().contains("Neo4j Enterprise Edition") {
+                eprintln!("Skipping test: {}", e);
+                return;
+            }
+
+            std::panic::panic_any(e);
         }
     };
     let graph = neo4j.graph();

--- a/lib/tests/use_default_db.rs
+++ b/lib/tests/use_default_db.rs
@@ -1,0 +1,69 @@
+use futures::TryStreamExt;
+use neo4rs::*;
+
+mod container;
+
+#[tokio::test]
+async fn use_default_db() {
+    let dbname = uuid::Uuid::new_v4().to_string().replace(['-', '_'], "");
+
+    let neo4j = match container::Neo4jContainerBuilder::new()
+        .with_server_config("initial.dbms.default_database", dbname.as_str())
+        .with_enterprise_edition()
+        .start()
+        .await
+    {
+        Ok(n) => n,
+        Err(e) => {
+            if e.to_string().contains("Neo4j Enterprise Edition") {
+                eprintln!("Skipping test: {}", e);
+                return;
+            }
+
+            std::panic::panic_any(e);
+        }
+    };
+    let graph = neo4j.graph();
+
+    let default_db = graph
+        .execute_on("system", query("SHOW DEFAULT DATABASE"))
+        .await
+        .unwrap()
+        .column_into_stream::<String>("name")
+        .try_fold(None::<String>, |acc, db| async { Ok(acc.or(Some(db))) })
+        .await
+        .unwrap()
+        .unwrap();
+
+    if default_db != dbname {
+        eprintln!(
+            concat!(
+                "Skipping test: The test must run against a testcontainer ",
+                "or have `{}` configured as the default database"
+            ),
+            dbname
+        );
+        return;
+    }
+
+    let id = uuid::Uuid::new_v4();
+    graph
+        .run(query("CREATE (:Node { uuid: $uuid })").param("uuid", id.to_string()))
+        .await
+        .unwrap();
+
+    let count = graph
+        .execute_on(
+            dbname.as_str(),
+            query("MATCH (n:Node {uuid: $uuid}) RETURN count(n) AS result")
+                .param("uuid", id.to_string()),
+        )
+        .await
+        .unwrap()
+        .column_into_stream::<u64>("result")
+        .try_fold(0, |sum, count| async move { Ok(sum + count) })
+        .await
+        .unwrap();
+
+    assert_eq!(count, 1);
+}


### PR DESCRIPTION
- **Add option to pass env and server config to testcontainers**
- **Run testcontainers async as all tests are async as well**
- **Only skip EE test when the license was not accepted**
- **Add test to show that the server default db is used**
- **Use server default db over hardcoded default db**
