### PR TITLE
Add Ignore to current Bolt implementation

### DIFF
--- a/lib/src/messages.rs
+++ b/lib/src/messages.rs
@@ -4,14 +4,15 @@ mod commit;
 mod discard;
 mod failure;
 mod hello;
+mod ignore;
 mod pull;
 mod record;
 mod reset;
 mod rollback;
 mod run;
 mod success;
-mod ignore;
 
+use crate::messages::ignore::Ignore;
 use crate::{
     errors::{Error, Result},
     types::{BoltMap, BoltWireFormat},
@@ -24,7 +25,6 @@ use failure::Failure;
 use record::Record;
 use run::Run;
 pub(crate) use success::Success;
-use crate::messages::ignore::Ignore;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum BoltResponse {
@@ -231,7 +231,10 @@ impl BoltResponse {
         }
         Err(Error::UnknownMessage(format!(
             "unknown message {}",
-            response.iter().map(|byte| format!("{:02X}", byte)).collect::<String>()
+            response
+                .iter()
+                .map(|byte| format!("{:02X}", byte))
+                .collect::<String>()
         )))
     }
 

--- a/lib/src/messages.rs
+++ b/lib/src/messages.rs
@@ -229,12 +229,13 @@ impl BoltResponse {
             let ignore = Ignore::parse(version, &mut response)?;
             return Ok(BoltResponse::Ignore(ignore));
         }
-        Err(Error::UnknownMessage(format!(
-            "unknown message {}",
-            response
-                .iter()
-                .map(|byte| format!("{:02X}", byte))
-                .collect::<String>()
+        Err(Error::UnknownMessage(response.iter().fold(
+            "unknown message ".to_owned(),
+            |mut output, byte| {
+                use std::fmt::Write;
+                let _ = write!(output, "{:02X}", byte);
+                output
+            },
         )))
     }
 

--- a/lib/src/messages/ignore.rs
+++ b/lib/src/messages/ignore.rs
@@ -1,0 +1,38 @@
+use crate::{
+    errors::Neo4jError,
+};
+use neo4rs_macros::BoltStruct;
+
+#[derive(Debug, PartialEq, Clone, BoltStruct)]
+#[signature(0xB0, 0x7E)]
+pub struct Ignore;
+
+impl Ignore {
+    pub(crate) fn into_error(self) -> Neo4jError {
+        Neo4jError::new("Neo.ServerError.Ignored".into(), "The request was ignored by the server because it is in a FAILED or INTERRUPTED state".into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::BoltWireFormat;
+    use crate::version::Version;
+    use bytes::Bytes;
+
+    #[test]
+    fn should_deserialize_success() {
+        let mut data = Bytes::from_static(&[
+            0xB0, 0x7E,
+        ]);
+
+        let failure: Ignore = Ignore::parse(Version::V4_1, &mut data).unwrap();
+        let failure = failure.into_error();
+
+        assert_eq!(failure.code(), "Neo.ServerError.Ignored");
+        assert_eq!(
+            failure.message(),
+            "The request was ignored by the server because it is in a FAILED or INTERRUPTED state"
+        );
+    }
+}

--- a/lib/src/messages/ignore.rs
+++ b/lib/src/messages/ignore.rs
@@ -1,6 +1,4 @@
-use crate::{
-    errors::Neo4jError,
-};
+use crate::errors::Neo4jError;
 use neo4rs_macros::BoltStruct;
 
 #[derive(Debug, PartialEq, Clone, BoltStruct)]
@@ -9,7 +7,11 @@ pub struct Ignore;
 
 impl Ignore {
     pub(crate) fn into_error(self) -> Neo4jError {
-        Neo4jError::new("Neo.ServerError.Ignored".into(), "The request was ignored by the server because it is in a FAILED or INTERRUPTED state".into())
+        Neo4jError::new(
+            "Neo.ServerError.Ignored".into(),
+            "The request was ignored by the server because it is in a FAILED or INTERRUPTED state"
+                .into(),
+        )
     }
 }
 
@@ -22,9 +24,7 @@ mod tests {
 
     #[test]
     fn should_deserialize_success() {
-        let mut data = Bytes::from_static(&[
-            0xB0, 0x7E,
-        ]);
+        let mut data = Bytes::from_static(&[0xB0, 0x7E]);
 
         let failure: Ignore = Ignore::parse(Version::V4_1, &mut data).unwrap();
         let failure = failure.into_error();

--- a/lib/src/types/serde/de.rs
+++ b/lib/src/types/serde/de.rs
@@ -168,7 +168,7 @@ impl<'de> Deserialize<'de> for Offset<FixedOffset> {
         }
         struct OffsetVisitor;
 
-        impl<'de> Visitor<'de> for OffsetVisitor {
+        impl Visitor<'_> for OffsetVisitor {
             type Value = FixedOffset;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {


### PR DESCRIPTION
I noticed the ignore message is only implemented under the unstable bolt implementation feature.
This PR adds support for it in the stable one.