### PR TITLE
Fix property parsing when a property contains a struct

### DIFF
--- a/lib/tests/node_property_parsing.rs
+++ b/lib/tests/node_property_parsing.rs
@@ -1,0 +1,23 @@
+use chrono::{DateTime, FixedOffset};
+use neo4rs::{query, Node};
+
+mod container;
+
+#[tokio::test]
+async fn node_property_parsing() {
+    let neo4j = container::Neo4jContainer::new().await;
+    let graph = neo4j.graph();
+
+    graph
+        .run(query("CREATE (:A {p1:DATETIME('2024-12-31T08:10:35')})"))
+        .await
+        .unwrap();
+
+    let mut result = graph.execute(query("MATCH (p:A) RETURN p")).await.unwrap();
+
+    while let Ok(Some(row)) = result.next().await {
+        let node: Node = row.get("p").unwrap();
+        let p1 = node.get::<DateTime<FixedOffset>>("p1").unwrap();
+        assert_eq!(p1.timestamp(), 1735632635);
+    }
+}


### PR DESCRIPTION
Properties are parsed lazily by deserializing the data into an `IgnoredAny`
and then returning the bytes that have been read.

We do parse structs as an enum in order to emit the struct tag as enum tag.
The `IgnoredAny` then deserializes a newtype enum variant, expecting a single item.
The `VariantAccess` impl for the packstream deserializer would then only emit the next field in the struct, introducing the bug.
The fix is to emit all fields when the list of items is from a struct and we are parsing properties.

Fixes #209

