### PR TITLE
Always skip ssl validation when using a self-signed certificate

### DIFF
--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -150,12 +150,17 @@ impl ConfigBuilder {
         self
     }
 
+    /// A CA certificate to use to validate the server's certificate.
+    /// 
+    /// This is required if the server's certificate is not signed by a known CA.
     pub fn with_client_certificate(mut self, client_cert: impl AsRef<Path>) -> Self {
         self.tls_config =
             ConnectionTLSConfig::ClientCACertificate(ClientCertificate::new(client_cert));
         self
     }
 
+    /// Skip SSL validation. This is not recommended for production use.
+    /// This is true by default when connecting to the server using `neo4j+ssc` or 'bolt+ssc' schemes.
     pub fn skip_ssl_validation(mut self) -> Self {
         self.tls_config = ConnectionTLSConfig::NoSSLValidation;
         self

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -151,7 +151,7 @@ impl ConfigBuilder {
     }
 
     /// A CA certificate to use to validate the server's certificate.
-    /// 
+    ///
     /// This is required if the server's certificate is not signed by a known CA.
     pub fn with_client_certificate(mut self, client_cert: impl AsRef<Path>) -> Self {
         self.tls_config =

--- a/lib/src/connection.rs
+++ b/lib/src/connection.rs
@@ -337,7 +337,11 @@ impl ConnectionInfo {
         let encryption = encryption
             .then(|| {
                 // do not apply validation if using a self-signed certificate,as the documentation suggests
-                let config = if !validation { &ConnectionTLSConfig::NoSSLValidation } else { tls_config };
+                let config = if !validation {
+                    &ConnectionTLSConfig::NoSSLValidation
+                } else {
+                    tls_config
+                };
                 Self::tls_connector(url.host(), config)
             })
             .transpose()?;

--- a/lib/src/connection.rs
+++ b/lib/src/connection.rs
@@ -324,18 +324,22 @@ impl ConnectionInfo {
     ) -> Result<Self> {
         let mut url = NeoUrl::parse(uri)?;
 
-        let (routing, encryption) = match url.scheme() {
-            "bolt" | "" => (false, false),
-            "bolt+s" => (false, true),
-            "bolt+ssc" => (false, true),
-            "neo4j" => (true, false),
-            "neo4j+s" => (true, true),
-            "neo4j+ssc" => (true, true),
+        let (routing, encryption, validation) = match url.scheme() {
+            "bolt" | "" => (false, false, false),
+            "bolt+s" => (false, true, true),
+            "bolt+ssc" => (false, true, false),
+            "neo4j" => (true, false, false),
+            "neo4j+s" => (true, true, true),
+            "neo4j+ssc" => (true, true, false),
             otherwise => return Err(Error::UnsupportedScheme(otherwise.to_owned())),
         };
 
         let encryption = encryption
-            .then(|| Self::tls_connector(url.host(), tls_config))
+            .then(|| {
+                // do not apply validation if using a self-signed certificate,as the documentation suggests
+                let config = if !validation { &ConnectionTLSConfig::NoSSLValidation } else { tls_config };
+                Self::tls_connector(url.host(), config)
+            })
             .transpose()?;
 
         let routing = if routing {


### PR DESCRIPTION
This PR fixes an erroneous behavior of the driver when using a self-signed certificate. The documentation says:
```
The +s variants enable encryption with a full certificate check, and the +ssc variants enable encryption, 
but with no certificate check. This latter variant is designed specifically for use with self-signed certificates.
```
