### PR TITLE
Handle ignored message as a failure

### DIFF
--- a/lib/src/stream.rs
+++ b/lib/src/stream.rs
@@ -233,7 +233,10 @@ impl RowStream {
                             None
                         }
                     },
-                    Summary::Ignored => None,
+                    Summary::Ignored => {
+                        self.state = State::Complete(None);
+                        return Err(Error::RequestIgnoredError);
+                    }
                     Summary::Failure(f) => {
                         self.state = State::Complete(None);
                         return Err(f.into_error());


### PR DESCRIPTION
# Description

This pull request includes a change to the error handling in the `RowStream` implementation in `lib/src/stream.rs`. The change ensures that the state is set to `Complete(None)` and an `Error::RequestIgnoredError` is returned when the summary is `Ignored`. This because the documentation states:
```
The IGNORED message indicates that the corresponding request has not been carried out.
```
For the RUN command the doc also says:
```
If the server is in a FAILED or INTERRUPTED state, the request will be IGNORED.
```

Error handling improvement:

* [`lib/src/stream.rs`](diffhunk://#diff-5bd844c6f2397bf3b93c5b08057eee21c5cf71899a4c8ce247cd94a4238ec81bL236-R239): Modified the handling of `Summary::Ignored` to set the state to `Complete(None)` and return an `Error::RequestIgnoredError`.