### PR TITLE
Creating a Graph doesn't have to be async

### DIFF
--- a/lib/examples/concurrent_writes.rs
+++ b/lib/examples/concurrent_writes.rs
@@ -18,7 +18,6 @@ async fn main() {
             .build()
             .unwrap(),
     )
-    .await
     .unwrap();
 
     stream::iter(1..=1337)

--- a/lib/src/graph.rs
+++ b/lib/src/graph.rs
@@ -66,7 +66,7 @@ impl Graph {
     /// Connects to the database with configurations provided.
     ///
     /// You can build a config using [`ConfigBuilder::default()`].
-    pub async fn connect(config: Config) -> Result<Self> {
+    pub fn connect(config: Config) -> Result<Self> {
         #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
         {
             let info = ConnectionInfo::new(
@@ -77,16 +77,16 @@ impl Graph {
             )?;
             if matches!(info.routing, Routing::Yes(_)) {
                 debug!("Routing enabled, creating a routed connection manager");
-                let pool = Routed(
-                    RoutedConnectionManager::new(&config, Box::new(ClusterRoutingTableProvider))
-                        .await?,
-                );
+                let pool = Routed(RoutedConnectionManager::new(
+                    &config,
+                    Box::new(ClusterRoutingTableProvider),
+                )?);
                 Ok(Graph {
                     config: config.into_live_config(),
                     pool,
                 })
             } else {
-                let pool = Direct(create_pool(&config).await?);
+                let pool = Direct(create_pool(&config)?);
                 Ok(Graph {
                     config: config.into_live_config(),
                     pool,
@@ -95,7 +95,7 @@ impl Graph {
         }
         #[cfg(not(feature = "unstable-bolt-protocol-impl-v2"))]
         {
-            let pool = Direct(create_pool(&config).await?);
+            let pool = Direct(create_pool(&config)?);
             Ok(Graph {
                 config: config.into_live_config(),
                 pool,
@@ -104,7 +104,7 @@ impl Graph {
     }
 
     /// Connects to the database with default configurations
-    pub async fn new(
+    pub fn new(
         uri: impl Into<String>,
         user: impl Into<String>,
         password: impl Into<String>,
@@ -114,7 +114,7 @@ impl Graph {
             .user(user)
             .password(password)
             .build()?;
-        Self::connect(config).await
+        Self::connect(config)
     }
 
     /// Starts a new transaction on the configured database.

--- a/lib/src/pool.rs
+++ b/lib/src/pool.rs
@@ -55,7 +55,7 @@ impl Manager for ConnectionManager {
     }
 }
 
-pub async fn create_pool(config: &Config) -> Result<ConnectionPool> {
+pub fn create_pool(config: &Config) -> Result<ConnectionPool> {
     let mgr = ConnectionManager::new(
         &config.uri,
         &config.user,

--- a/lib/src/routing/connection_registry.rs
+++ b/lib/src/routing/connection_registry.rs
@@ -90,8 +90,7 @@ async fn refresh_routing_table(
             create_pool(&Config {
                 uri,
                 ..config.clone()
-            })
-            .await?,
+            })?,
         );
     }
     registry.connections.retain(|k, _| servers.contains(k));
@@ -103,7 +102,7 @@ async fn refresh_routing_table(
     Ok(routing_table.ttl)
 }
 
-pub(crate) async fn start_background_updater(
+pub(crate) fn start_background_updater(
     config: &Config,
     registry: Arc<ConnectionRegistry>,
     provider: Arc<Box<dyn RoutingTableProvider>>,

--- a/lib/src/routing/routed_connection_manager.rs
+++ b/lib/src/routing/routed_connection_manager.rs
@@ -25,10 +25,7 @@ pub struct RoutedConnectionManager {
 }
 
 impl RoutedConnectionManager {
-    pub async fn new(
-        config: &Config,
-        provider: Box<dyn RoutingTableProvider>,
-    ) -> Result<Self, Error> {
+    pub fn new(config: &Config, provider: Box<dyn RoutingTableProvider>) -> Result<Self, Error> {
         let backoff = Arc::new(
             ExponentialBackoffBuilder::new()
                 .with_initial_interval(Duration::from_millis(1))
@@ -40,7 +37,7 @@ impl RoutedConnectionManager {
 
         let connection_registry = Arc::new(ConnectionRegistry::default());
         let channel =
-            start_background_updater(config, connection_registry.clone(), provider.into()).await;
+            start_background_updater(config, connection_registry.clone(), provider.into());
         Ok(RoutedConnectionManager {
             load_balancing_strategy: Arc::new(RoundRobinStrategy::default()),
             bookmarks: Arc::new(Mutex::new(vec![])),

--- a/lib/tests/container.rs
+++ b/lib/tests/container.rs
@@ -245,7 +245,7 @@ impl Neo4jContainer {
             .build()
             .unwrap();
 
-        Graph::connect(config).await.unwrap()
+        Graph::connect(config).unwrap()
     }
 }
 


### PR DESCRIPTION
The first connection is done when the first query is run, no need for an async graph creation.

BREAKING CHANGE: The Graph::new and Graph::connect methods are no longer `async`, any `.await` after calling them must be removed.