### PR TITLE
Let finish function take a mutable reference of self (like next)

### DIFF
--- a/lib/src/query.rs
+++ b/lib/src/query.rs
@@ -129,7 +129,7 @@ impl Query {
         request: BoltRequest,
         connection: &mut ManagedConnection,
     ) -> QueryResult<RunResult> {
-        let result = Self::try_execute(request, 4096, connection).await?;
+        let mut result = Self::try_execute(request, 4096, connection).await?;
         Ok(result.finish(connection).await?)
     }
 

--- a/lib/src/stream.rs
+++ b/lib/src/stream.rs
@@ -245,11 +245,11 @@ impl RowStream {
 
     /// Stop consuming the stream and return a summary, if available.
     /// Stopping the stream will also discard any messages on the server side.
-    pub async fn finish(mut self, mut handle: impl TransactionHandle) -> Result<RunResult> {
+    pub async fn finish(&mut self, mut handle: impl TransactionHandle) -> Result<RunResult> {
         self.buffer.clear();
 
         #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
-        match self.state {
+        match &self.state {
             State::Ready => {
                 let summary = {
                     let connected = handle.connection();
@@ -273,7 +273,7 @@ impl RowStream {
                 };
                 Ok(summary)
             }
-            State::Complete(summary) => Ok(*summary),
+            State::Complete(summary) => Ok(*summary.clone()),
         }
 
         #[cfg(not(feature = "unstable-bolt-protocol-impl-v2"))]
@@ -435,7 +435,7 @@ impl DetachedRowStream {
 
     /// Stop consuming the stream and return a summary, if available.
     /// Stopping the stream will also discard any messages on the server side.
-    pub async fn finish(mut self) -> Result<RunResult> {
+    pub async fn finish(&mut self) -> Result<RunResult> {
         self.stream.finish(&mut self.connection).await
     }
 


### PR DESCRIPTION
This PR changes the signatures of the finish function in the stream.rs file. The reason behind this change is that `next()` takes a mutable reference of self, while `finish()` requires a mutable self (which would move the stream). 
With the current implementation is not possible to take the stream and consume it using `next()` and then call the `finish()` at the end, making it impossible to implement an iterator over the result. For example this code would fail because when trying to use `self.stream.finish()` the compiler says `DetachedRowStream::finish` takes ownership of the receiver `self`, which moves `self.stream`:
```
pub trait AsyncIterator {
    type Item;
    fn next(&mut self) -> impl Future<Output = Option<Self::Item>> + Send;
}

enum MyStreamItem {
    Item(String),
    Summary(String),
    Error(String),
};

MyExecutorStream {
    stream: DetachedRowStream,
}

impl AsyncIterator for MyExecutorStream {
    type Item = MyStreamItem;

    fn next(&mut self) -> impl Future<Output = Option<Self::Item>> + Send {
        async {
           let match self.stream.next().await { 
               // handle items from neo4j and transform them into MyStreamItem
               MyStreamItem::Item(...)
           };
           if option.is_none() {
               let some = self.stream.finish().await;
               if let Err(err) = some {
                   // handle error
                   MyStreamItem::Error(...)
               } else {
                   // handle run result
                   MyStreamItem::Summary(...)
               }
          } else {
               option
          }
    }
}
```

The side effect of this change is that we need to clone the summary to return it.
Let me know if I am mistaken here and I should deal with the problem differently.