### PR TITLE
Add bookmarks support

### DIFF
--- a/lib/include/bookmarks.rs
+++ b/lib/include/bookmarks.rs
@@ -7,6 +7,7 @@
     let mut result = graph.execute(query("MATCH (p:Person) WHERE p.id = $id RETURN p.id").param("id", id.clone())).await.unwrap();
     assert!(result.next().await.unwrap().is_none());
     let bookmark = txn.commit().await.unwrap();
+    assert!(bookmark.is_some());
     if let Some(ref b) = bookmark {
         println!("Got a bookmark after commit: {:?}", b);
     }

--- a/lib/include/bookmarks.rs
+++ b/lib/include/bookmarks.rs
@@ -1,0 +1,25 @@
+{
+    let mut txn = graph.start_txn().await.expect("Failed to start a new transaction");
+    let id = uuid::Uuid::new_v4().to_string();
+    txn.run(query("CREATE (p:Person {id: $id})").param("id", id.clone())).await.unwrap();
+    txn.run(query("CREATE (p:Person {id: $id})").param("id", id.clone())).await.unwrap();
+    // graph.execute(..) will not see the changes done above as the txn is not committed yet
+    let mut result = graph.execute(query("MATCH (p:Person) WHERE p.id = $id RETURN p.id").param("id", id.clone())).await.unwrap();
+    assert!(result.next().await.unwrap().is_none());
+    let bookmark = txn.commit().await.unwrap();
+    if let Some(ref b) = bookmark {
+        println!("Got a bookmark after commit: {:?}", b);
+    }
+
+    //changes are now seen as the transaction is committed.
+    let mut txn = graph.start_txn_as(Operation::Read, bookmark.map(|b| vec![b])).await.expect("Failed to start a new transaction");
+    let mut stream = txn.execute(query("MATCH (p:Person) WHERE p.id = $id RETURN p.id").param("id", id.clone())).await.unwrap();
+    loop {
+        let next = stream.next(txn.handle());
+        if let Ok(Some(record)) = next.await {
+            println!("Record: {:?}", record);
+        } else {
+            break;
+        }
+    }
+}

--- a/lib/src/bolt/mod.rs
+++ b/lib/src/bolt/mod.rs
@@ -14,7 +14,7 @@ mod structs;
 mod summary;
 
 pub use request::{
-    Commit, Discard, Goodbye, Hello, HelloBuilder, Pull, Reset, Rollback, WrapExtra,
+    Begin, Commit, Discard, Goodbye, Hello, HelloBuilder, Pull, Reset, Rollback, WrapExtra,
 };
 pub use structs::{
     Bolt, BoltRef, Date, DateDuration, DateTime, DateTimeZoneId, DateTimeZoneIdRef, Duration,

--- a/lib/src/bolt/request/begin.rs
+++ b/lib/src/bolt/request/begin.rs
@@ -58,7 +58,7 @@ impl<'a> BeginBuilder<'a> {
         }
     }
 
-    pub fn with_bookmarks(mut self, bookmarks: impl IntoIterator<Item=impl Display>) -> Self {
+    pub fn with_bookmarks(mut self, bookmarks: impl IntoIterator<Item = impl Display>) -> Self {
         self.bookmarks = bookmarks
             .into_iter()
             .map(|b| b.to_string())

--- a/lib/src/bolt/request/begin.rs
+++ b/lib/src/bolt/request/begin.rs
@@ -1,0 +1,277 @@
+use crate::bolt::{ExpectedResponse, Hello, Summary};
+use crate::routing::Route;
+use crate::{Database, Version};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt::Display;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Begin<'a> {
+    metadata: BeginMeta<'a>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BeginExtra<'a> {
+    V4(Option<&'a str>),
+    V4_4(Extra<'a>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub struct Extra<'a> {
+    pub(crate) db: Option<&'a str>,
+    pub(crate) imp_user: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TxMetadata(Vec<(String, String)>);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BeginMeta<'a> {
+    pub(crate) bookmarks: Vec<String>,
+    pub(crate) tx_timeout: Option<u32>,
+    pub(crate) tx_metadata: Option<TxMetadata>,
+    pub(crate) mode: &'a str,
+    pub(crate) extra: BeginExtra<'a>,
+    // To be added when implementing protocol version 5.2
+    // pub(crate) notifications_minimum_severity: &'a str,
+    // pub(crate) notifications_disabled_categories: Vec<String>
+}
+
+pub struct BeginBuilder<'a> {
+    bookmarks: Vec<String>,
+    tx_timeout: Option<u32>,
+    tx_metadata: Option<TxMetadata>,
+    mode: &'a str,
+    db: Option<&'a str>,
+    imp_user: Option<&'a str>,
+}
+
+impl<'a> BeginBuilder<'a> {
+    pub fn new(db: Option<&'a str>) -> Self {
+        Self {
+            bookmarks: Vec::new(),
+            tx_timeout: None,
+            tx_metadata: None,
+            mode: "w", // default is write mode
+            db,
+            imp_user: None,
+        }
+    }
+
+    pub fn with_bookmarks(mut self, bookmarks: Vec<impl Display>) -> Self {
+        self.bookmarks = bookmarks
+            .iter()
+            .map(|b| b.to_string())
+            .collect::<Vec<String>>();
+        self
+    }
+
+    pub fn with_tx_timeout(mut self, tx_timeout: u32) -> Self {
+        self.tx_timeout = Some(tx_timeout);
+        self
+    }
+
+    pub fn with_tx_metadata(mut self, tx_metadata: Vec<(String, String)>) -> Self {
+        self.tx_metadata = Some(TxMetadata(tx_metadata));
+        self
+    }
+
+    pub fn with_mode(mut self, mode: &'a str) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    pub fn with_imp_user(mut self, imp_user: &'a str) -> Self {
+        self.imp_user = Some(imp_user);
+        self
+    }
+
+    pub fn build(self, version: Version) -> Begin<'a> {
+        match version.cmp(&Version::V4_4) {
+            std::cmp::Ordering::Less => Begin {
+                metadata: BeginMeta {
+                    bookmarks: self.bookmarks,
+                    tx_timeout: self.tx_timeout,
+                    tx_metadata: self.tx_metadata,
+                    mode: self.mode,
+                    extra: BeginExtra::V4(self.db),
+                },
+            },
+            _ => Begin {
+                metadata: BeginMeta {
+                    bookmarks: self.bookmarks,
+                    tx_timeout: self.tx_timeout,
+                    tx_metadata: self.tx_metadata,
+                    mode: self.mode,
+                    extra: BeginExtra::V4_4(Extra {
+                        db: self.db,
+                        imp_user: self.imp_user,
+                    }),
+                },
+            },
+        }
+    }
+}
+
+impl<'a> Begin<'a> {
+    pub fn builder(db: Option<&'a str>) -> BeginBuilder<'a> {
+        BeginBuilder::new(db)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct Response {
+    pub(crate) db: Option<Database>,
+}
+
+impl ExpectedResponse for Begin<'_> {
+    type Response = Summary<Response>;
+}
+
+impl Serialize for Begin<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_newtype_variant("Request", 0x11, "BEGIN", &self.metadata)
+    }
+}
+
+impl Serialize for TxMetadata {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.0.len()))?;
+        for (k, v) in self.0.iter() {
+            map.serialize_entry(k, v)?;
+        }
+        map.end()
+    }
+}
+
+impl Serialize for BeginMeta<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut fields_count = 2; // minimum number of fields for the map
+        if self.tx_metadata.is_some() {
+            fields_count += 1;
+        }
+        if self.tx_timeout.is_some() {
+            fields_count += 1;
+        }
+
+        match &self.extra {
+            BeginExtra::V4(e) => {
+                if e.is_some() {
+                    fields_count += 1;
+                }
+            }
+            BeginExtra::V4_4(e) => {
+                if e.db.is_some() {
+                    fields_count += 1;
+                }
+                if e.imp_user.is_some() {
+                    fields_count += 1;
+                }
+            }
+        }
+
+        let mut map = serializer.serialize_map(Some(fields_count))?;
+        map.serialize_entry("bookmarks", &self.bookmarks)?;
+        map.serialize_entry("mode", &self.mode)?;
+        if let Some(tx_timeout) = self.tx_timeout {
+            map.serialize_entry("tx_timeout", &tx_timeout)?;
+        }
+        if let Some(tx_metadata) = self.tx_metadata.as_ref() {
+            map.serialize_entry("tx_metadata", tx_metadata)?;
+        }
+        match &self.extra {
+            BeginExtra::V4(db) => {
+                if let Some(db) = db {
+                    map.serialize_entry("db", db)?;
+                }
+            }
+            BeginExtra::V4_4(extra) => {
+                if let Some(db) = extra.db.as_ref() {
+                    map.serialize_entry("db", db)?;
+                }
+                if let Some(imp_user) = extra.imp_user.as_ref() {
+                    map.serialize_entry("imp_user", imp_user)?;
+                }
+            }
+        }
+        map.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Begin;
+    use crate::bolt::Message;
+    use crate::packstream::bolt;
+    use crate::{Database, Version};
+    use std::collections::HashMap;
+
+    #[test]
+    fn serialize() {
+        let begin = Begin::builder(None)
+            .with_bookmarks(vec!["example-bookmark:1", "example-bookmark:2"])
+            .with_tx_metadata(
+                [
+                    ("user".to_string(), "alice".to_string()),
+                    ("action".to_string(), "data_import".to_string()),
+                ]
+                .to_vec(),
+            )
+            .build(Version::V4);
+        let bytes = begin.to_bytes().unwrap();
+
+        let expected = bolt()
+            .structure(1, 0x11)
+            .tiny_map(3)
+            .tiny_string("bookmarks")
+            .tiny_list(2)
+            .string8("example-bookmark:1")
+            .string8("example-bookmark:2")
+            .tiny_string("mode")
+            .tiny_string("w")
+            .tiny_string("tx_metadata")
+            .tiny_map(2)
+            .tiny_string("user")
+            .tiny_string("alice")
+            .tiny_string("action")
+            .tiny_string("data_import")
+            .build();
+
+        assert_eq!(bytes, expected);
+
+        let db = Some(Database::from("neo4j"));
+        let begin = Begin::builder(db.as_deref())
+            .with_bookmarks(vec!["example-bookmark:1", "example-bookmark:2"])
+            .with_imp_user("my_user")
+            .build(Version::V4_4);
+        let bytes = begin.to_bytes().unwrap();
+
+        let expected = bolt()
+            .structure(1, 0x11)
+            .tiny_map(4)
+            .tiny_string("bookmarks")
+            .tiny_list(2)
+            .string8("example-bookmark:1")
+            .string8("example-bookmark:2")
+            .tiny_string("mode")
+            .tiny_string("w")
+            .tiny_string("db")
+            .tiny_string("neo4j")
+            .tiny_string("imp_user")
+            .tiny_string("my_user")
+            .build();
+
+        assert_eq!(bytes, expected);
+    }
+}

--- a/lib/src/bolt/request/begin.rs
+++ b/lib/src/bolt/request/begin.rs
@@ -1,9 +1,7 @@
-use crate::bolt::{ExpectedResponse, Hello, Summary};
-use crate::routing::Route;
+use crate::bolt::{ExpectedResponse, Summary};
 use crate::{Database, Version};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::fmt::Display;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -60,9 +58,9 @@ impl<'a> BeginBuilder<'a> {
         }
     }
 
-    pub fn with_bookmarks(mut self, bookmarks: Vec<impl Display>) -> Self {
+    pub fn with_bookmarks(mut self, bookmarks: impl IntoIterator<Item=impl Display>) -> Self {
         self.bookmarks = bookmarks
-            .iter()
+            .into_iter()
             .map(|b| b.to_string())
             .collect::<Vec<String>>();
         self
@@ -215,7 +213,6 @@ mod tests {
     use crate::bolt::Message;
     use crate::packstream::bolt;
     use crate::{Database, Version};
-    use std::collections::HashMap;
 
     #[test]
     fn serialize() {

--- a/lib/src/bolt/request/mod.rs
+++ b/lib/src/bolt/request/mod.rs
@@ -1,3 +1,4 @@
+mod begin;
 mod commit;
 mod discard;
 mod extra;
@@ -8,6 +9,7 @@ mod reset;
 mod rollback;
 mod route;
 
+pub use begin::Begin;
 pub use commit::Commit;
 pub use discard::Discard;
 pub use extra::WrapExtra;

--- a/lib/src/bolt/request/route.rs
+++ b/lib/src/bolt/request/route.rs
@@ -1,16 +1,16 @@
 use crate::bolt::{ExpectedResponse, Summary};
-use crate::connection::{NeoUrl, Routing};
+use crate::connection::Routing;
 use crate::routing::{Extra, Route, RouteExtra, RoutingTable};
 use serde::ser::{SerializeMap, SerializeStructVariant};
 use serde::{Deserialize, Serialize};
-use std::fmt::{format, Display, Formatter};
+use std::fmt::Display;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct Response {
     pub rt: RoutingTable,
 }
 
-impl ExpectedResponse for Route<'_> {
+impl ExpectedResponse for Route {
     type Response = Summary<Response>;
 }
 
@@ -32,7 +32,7 @@ impl Serialize for Routing {
     }
 }
 
-impl Serialize for Route<'_> {
+impl Serialize for Route {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -70,14 +70,14 @@ mod tests {
     use crate::bolt::{Message, MessageResponse};
     use crate::connection::Routing;
     use crate::packstream::bolt;
-    use crate::routing::{Route, RouteBuilder};
+    use crate::routing::RouteBuilder;
     use crate::{Database, Version};
 
     #[test]
     fn serialize() {
         let route = RouteBuilder::new(
             Routing::Yes(vec![("address".into(), "localhost:7687".into())]),
-            vec!["bookmark"],
+            vec!["bookmark".into()],
         )
         .with_db(Database::from("neo4j"))
         .build(Version::V4_3);
@@ -100,7 +100,7 @@ mod tests {
     fn serialize_no_db() {
         let builder = RouteBuilder::new(
             Routing::Yes(vec![("address".into(), "localhost:7687".into())]),
-            vec!["bookmark"],
+            vec!["bookmark".into()],
         );
         let route = builder.build(Version::V4_3);
         let serialized = route.to_bytes().unwrap();
@@ -122,7 +122,7 @@ mod tests {
     fn serialize_no_db_v4_4() {
         let builder = RouteBuilder::new(
             Routing::Yes(vec![("address".into(), "localhost:7687".into())]),
-            vec!["bookmark"],
+            vec!["bookmark".into()],
         );
         let route = builder.build(Version::V4_4);
         let serialized = route.to_bytes().unwrap();
@@ -148,7 +148,7 @@ mod tests {
     fn serialize_with_db_v4_4() {
         let builder = RouteBuilder::new(
             Routing::Yes(vec![("address".into(), "localhost:7687".into())]),
-            vec!["bookmark"],
+            vec!["bookmark".into()],
         );
         let route = builder
             .with_db("neo4j".into())

--- a/lib/src/bookmarks.rs
+++ b/lib/src/bookmarks.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "unstable-bolt-protocol-impl-v2")]
+pub(crate) trait Bookmark {
+    fn get_bookmark(&self) -> Option<&str>;
+}

--- a/lib/src/connection.rs
+++ b/lib/src/connection.rs
@@ -127,7 +127,7 @@ impl Connection {
     }
 
     #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
-    pub async fn route(&mut self, route: Route<'_>) -> Result<RoutingTable> {
+    pub async fn route(&mut self, route: Route) -> Result<RoutingTable> {
         debug!("Routing request: {}", route);
         let route = self.send_recv_as(route).await?;
 

--- a/lib/src/graph.rs
+++ b/lib/src/graph.rs
@@ -123,7 +123,7 @@ impl Graph {
     ///
     /// Transactions will not be automatically retried on any failure.
     pub async fn start_txn(&self) -> Result<Txn> {
-        self.impl_start_txn_on(self.config.db.clone(), Operation::Write)
+        self.impl_start_txn_on(self.config.db.clone(), Operation::Write, &[])
             .await
     }
 
@@ -133,9 +133,17 @@ impl Graph {
     ///
     /// Transactions will not be automatically retried on any failure.
     #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
-    pub async fn start_txn_as(&self, operation: Operation) -> Result<Txn> {
-        self.impl_start_txn_on(self.config.db.clone(), operation)
-            .await
+    pub async fn start_txn_as(
+        &self,
+        operation: Operation,
+        bookmarks: Option<Vec<String>>,
+    ) -> Result<Txn> {
+        self.impl_start_txn_on(
+            self.config.db.clone(),
+            operation,
+            bookmarks.as_deref().unwrap_or_default(),
+        )
+        .await
     }
 
     /// Starts a new transaction on the provided database.
@@ -144,14 +152,26 @@ impl Graph {
     ///
     /// Transactions will not be automatically retried on any failure.
     pub async fn start_txn_on(&self, db: impl Into<Database>) -> Result<Txn> {
-        self.impl_start_txn_on(Some(db.into()), Operation::Write)
+        self.impl_start_txn_on(Some(db.into()), Operation::Write, &[])
             .await
     }
 
     #[allow(unused_variables)]
-    async fn impl_start_txn_on(&self, db: Option<Database>, operation: Operation) -> Result<Txn> {
+    async fn impl_start_txn_on(
+        &self,
+        db: Option<Database>,
+        operation: Operation,
+        bookmarks: &[String],
+    ) -> Result<Txn> {
         let connection = self.pool.get(Some(operation.clone())).await?;
-        Txn::new(db, self.config.fetch_size, connection, operation).await
+        #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
+        {
+            Txn::new(db, self.config.fetch_size, connection, operation, bookmarks).await
+        }
+        #[cfg(not(feature = "unstable-bolt-protocol-impl-v2"))]
+        {
+            Txn::new(db, self.config.fetch_size, connection, operation).await
+        }
     }
 
     /// Runs a query on the configured database using a connection from the connection pool,
@@ -204,7 +224,8 @@ impl Graph {
         q: Query,
         operation: Operation,
     ) -> Result<RunResult> {
-        backoff::future::retry_notify(
+        let is_read = operation.is_read();
+        let result = backoff::future::retry_notify(
             self.pool.backoff(),
             || {
                 let pool = &self.pool;
@@ -213,13 +234,7 @@ impl Graph {
                 if let Some(db) = db.as_deref() {
                     query = query.extra("db", db);
                 }
-                query = query.extra(
-                    "mode",
-                    match operation {
-                        Operation::Read => "r",
-                        Operation::Write => "w",
-                    },
-                );
+                query = query.extra("mode", if is_read { "r" } else { "w" });
                 async move {
                     let mut connection =
                         pool.get(Some(operation)).await.map_err(Error::Permanent)?; // an error when retrieving a connection is considered permanent
@@ -228,7 +243,33 @@ impl Graph {
             },
             Self::log_retry,
         )
-        .await
+        .await;
+
+        match result {
+            Ok(result) => {
+                #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
+                {
+                    if let Some(bookmark) = result.bookmark.as_deref() {
+                        match &self.pool {
+                            Routed(routed) => {
+                                routed.add_bookmark(bookmark).await;
+                            }
+                            Direct(_) => {}
+                        }
+                    } else if is_read {
+                        match &self.pool {
+                            Routed(routed) => {
+                                debug!("No bookmark received after a read operation, discarding all bookmarks");
+                                routed.clear_bookmarks().await;
+                            }
+                            Direct(_) => {}
+                        }
+                    }
+                }
+                Ok(result)
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// Executes a READ/WRITE query on the configured database and returns a [`DetachedRowStream`]
@@ -303,13 +344,7 @@ impl Graph {
                     query = query.extra("db", db);
                 }
                 let operation = operation.clone();
-                query = query.param(
-                    "mode",
-                    match operation {
-                        Operation::Read => "r",
-                        Operation::Write => "w",
-                    },
-                );
+                query = query.param("mode", if operation.is_read() { "r" } else { "w" });
                 async move {
                     let connection = pool.get(Some(operation)).await.map_err(Error::Permanent)?; // an error when retrieving a connection is considered permanent
                     query.execute_retryable(fetch_size, connection).await

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -148,6 +148,28 @@
 //!
 //! ```
 //!
+//! ### Bookmarks and transactions
+//!
+//! Start a new transaction using [`Graph::start_txn`], which will return a handle [`Txn`] that can
+//! be used to [`Txn::commit`] or [`Txn::rollback`] the transaction. The commit message eventually returns
+//! a bookmark which can be used to start a new transaction with the same state.
+//!
+//!
+//! ```no_run
+//! use neo4rs::*;
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!    let uri = "127.0.0.1:7687";
+//!    let user = "neo4j";
+//!    let pass = "neo";
+//!    let graph = Graph::new(uri, user, pass).unwrap();
+//!
+#![doc = include_str!("../include/bookmarks.rs")]
+//! }
+//!
+//! ```
+//!
 #![cfg_attr(
     feature = "unstable-result-summary",
     doc = r##"### Streaming summary
@@ -166,7 +188,10 @@ async fn main() {
 
 "##
 )]
-#![cfg_attr(feature="unstable-result-summary", doc = include_str!("../include/result_summary.rs"))]
+#![cfg_attr(
+    feature = "unstable-result-summary",
+    doc = include_str!("../include/result_summary.rs")
+)]
 #![cfg_attr(
     feature = "unstable-result-summary",
     doc = r"
@@ -451,6 +476,7 @@ async fn main() {
 mod auth;
 #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
 pub mod bolt;
+mod bookmarks;
 mod config;
 mod connection;
 mod convert;
@@ -491,14 +517,19 @@ pub use crate::types::{
     BoltPoint2D, BoltPoint3D, BoltRelation, BoltString, BoltTime, BoltType, BoltUnboundedRelation,
 };
 pub use crate::version::Version;
-use std::fmt::Display;
-
 pub(crate) use messages::Success;
+use std::fmt::Display;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Operation {
     Read,
     Write,
+}
+
+impl Operation {
+    pub fn is_read(&self) -> bool {
+        matches!(self, Operation::Read)
+    }
 }
 
 impl Display for Operation {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -148,28 +148,38 @@
 //!
 //! ```
 //!
-//! ### Bookmarks and transactions
-//!
-//! Start a new transaction using [`Graph::start_txn`], which will return a handle [`Txn`] that can
-//! be used to [`Txn::commit`] or [`Txn::rollback`] the transaction. The commit message eventually returns
-//! a bookmark which can be used to start a new transaction with the same state.
-//!
-//!
-//! ```no_run
-//! use neo4rs::*;
-//!
-//! #[tokio::main]
-//! async fn main() {
-//!    let uri = "127.0.0.1:7687";
-//!    let user = "neo4j";
-//!    let pass = "neo";
-//!    let graph = Graph::new(uri, user, pass).unwrap();
-//!
-#![doc = include_str!("../include/bookmarks.rs")]
-//! }
-//!
-//! ```
-//!
+#![cfg_attr(
+    feature = "unstable-bolt-protocol-impl-v2",
+    doc = r##"### Bookmarks and transactions
+
+Start a new transaction using [`Graph::start_txn`], which will return a handle [`Txn`] that can
+be used to [`Txn::commit`] or [`Txn::rollback`] the transaction. The commit message eventually returns
+a bookmark which can be used to start a new transaction with the same state.
+
+```no_run
+use neo4rs::*;
+
+#[tokio::main]
+async fn main() {
+   let uri = "127.0.0.1:7687";
+   let user = "neo4j";
+   let pass = "neo";
+   let graph = Graph::new(uri, user, pass).unwrap();
+
+"##
+)]
+#![cfg_attr(
+    feature = "unstable-bolt-protocol-impl-v2",
+    doc = include_str!("../include/bookmarks.rs")
+)]
+#![cfg_attr(
+    feature = "unstable-bolt-protocol-impl-v2",
+    doc = r"
+}
+```
+
+"
+)]
 #![cfg_attr(
     feature = "unstable-result-summary",
     doc = r##"### Streaming summary

--- a/lib/src/messages.rs
+++ b/lib/src/messages.rs
@@ -165,7 +165,7 @@ impl BoltRequest {
 
     #[cfg_attr(
         feature = "unstable-bolt-protocol-impl-v2",
-        deprecated(since = "0.9.0", note = "Use `crate::bolt::Discard` instead.")
+        deprecated(since = "0.9.0", note = "Use `crate::bolt::Begin` instead.")
     )]
     pub fn begin(db: Option<&str>) -> BoltRequest {
         let extra = db.into_iter().map(|db| ("db".into(), db.into())).collect();

--- a/lib/src/messages.rs
+++ b/lib/src/messages.rs
@@ -163,6 +163,10 @@ impl BoltRequest {
         BoltRequest::Discard(discard::Discard::new(-1, query_id))
     }
 
+    #[cfg_attr(
+        feature = "unstable-bolt-protocol-impl-v2",
+        deprecated(since = "0.9.0", note = "Use `crate::bolt::Discard` instead.")
+    )]
     pub fn begin(db: Option<&str>) -> BoltRequest {
         let extra = db.into_iter().map(|db| ("db".into(), db.into())).collect();
         let begin = Begin::new(extra);

--- a/lib/src/routing/connection_registry.rs
+++ b/lib/src/routing/connection_registry.rs
@@ -7,8 +7,8 @@ use dashmap::DashMap;
 use log::debug;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::{mpsc, Mutex};
 
 /// Represents a Bolt server, with its address, port and role.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -48,7 +48,7 @@ pub(crate) struct ConnectionRegistry {
 
 #[allow(dead_code)]
 pub(crate) enum RegistryCommand {
-    Refresh,
+    Refresh(Vec<String>),
     Stop,
 }
 
@@ -64,10 +64,14 @@ async fn refresh_routing_table(
     config: Config,
     registry: Arc<ConnectionRegistry>,
     provider: Arc<Box<dyn RoutingTableProvider>>,
+    bookmarks: &[String],
 ) -> Result<u64, Error> {
     debug!("Routing table expired or empty, refreshing...");
-    let routing_table = provider.fetch_routing_table(&config).await?;
-    debug!("Routing table refreshed: {:?}", routing_table);
+    let routing_table = provider.fetch_routing_table(&config, bookmarks).await?;
+    debug!(
+        "Routing table refreshed: {:?} (bookmarks: {:?})",
+        routing_table, bookmarks
+    );
     let servers = routing_table.resolve();
     let url = NeoUrl::parse(config.uri.as_str())?;
     // Convert neo4j scheme to bolt scheme to create connection pools.
@@ -109,13 +113,17 @@ pub(crate) fn start_background_updater(
 ) -> Sender<RegistryCommand> {
     let config_clone = config.clone();
     let (tx, mut rx) = mpsc::channel(1);
-
+    let bookmarks = Mutex::new(vec![]);
     // This thread is in charge of refreshing the routing table periodically
     tokio::spawn(async move {
-        let mut ttl =
-            refresh_routing_table(config_clone.clone(), registry.clone(), provider.clone())
-                .await
-                .expect("Failed to get routing table. Exiting...");
+        let mut ttl = refresh_routing_table(
+            config_clone.clone(),
+            registry.clone(),
+            provider.clone(),
+            bookmarks.lock().await.as_slice(),
+        )
+        .await
+        .expect("Failed to get routing table. Exiting...");
         debug!("Starting background updater with TTL: {}", ttl);
         let mut interval = tokio::time::interval(Duration::from_secs(ttl));
         interval.tick().await; // first tick is immediate
@@ -123,7 +131,7 @@ pub(crate) fn start_background_updater(
             tokio::select! {
                 // Trigger periodic updates
                 _ = interval.tick() => {
-                    ttl = match refresh_routing_table(config_clone.clone(), registry.clone(), provider.clone()).await {
+                    ttl = match refresh_routing_table(config_clone.clone(), registry.clone(), provider.clone(), bookmarks.lock().await.as_slice()).await {
                         Ok(ttl) => ttl,
                         Err(e) => {
                             debug!("Failed to refresh routing table: {}", e);
@@ -135,8 +143,9 @@ pub(crate) fn start_background_updater(
                 // Handle forced updates
                 cmd = rx.recv() => {
                     match cmd {
-                        Some(RegistryCommand::Refresh) => {
-                            ttl = match refresh_routing_table(config_clone.clone(), registry.clone(), provider.clone()).await {
+                        Some(RegistryCommand::Refresh(new_bookmarks)) => {
+                            *bookmarks.lock().await = new_bookmarks;
+                            ttl = match refresh_routing_table(config_clone.clone(), registry.clone(), provider.clone(), bookmarks.lock().await.as_slice()).await {
                                 Ok(ttl) => ttl,
                                 Err(e) => {
                                     debug!("Failed to refresh routing table: {}", e);
@@ -201,6 +210,7 @@ mod tests {
         fn fetch_routing_table(
             &self,
             _: &Config,
+            _bookmarks: &[String],
         ) -> Pin<Box<dyn Future<Output = Result<RoutingTable, Error>> + Send>> {
             let routing_table = self.routing_table.clone();
             Box::pin(async move { Ok(routing_table) })
@@ -259,6 +269,7 @@ mod tests {
             Arc::new(Box::new(TestRoutingTableProvider::new(
                 cluster_routing_table,
             ))),
+            &[],
         )
         .await
         .unwrap();

--- a/lib/src/routing/routed_connection_manager.rs
+++ b/lib/src/routing/routed_connection_manager.rs
@@ -18,7 +18,6 @@ use tokio::sync::mpsc::Sender;
 pub struct RoutedConnectionManager {
     load_balancing_strategy: Arc<dyn LoadBalancingStrategy>,
     connection_registry: Arc<ConnectionRegistry>,
-    #[allow(dead_code)]
     bookmarks: Arc<Mutex<Vec<String>>>,
     backoff: Arc<ExponentialBackoff>,
     channel: Sender<RegistryCommand>,
@@ -52,48 +51,60 @@ impl RoutedConnectionManager {
         operation: Option<Operation>,
     ) -> Result<ManagedConnection, Error> {
         let op = operation.unwrap_or(Operation::Write);
-        while let Some(server) = match op {
-            Operation::Write => self.select_writer(),
-            _ => self.select_reader(),
-        } {
-            debug!("requesting connection for server: {:?}", server);
-            if let Some(pool) = self.connection_registry.get_pool(&server) {
-                match pool.get().await {
-                    Ok(connection) => return Ok(connection),
-                    Err(e) => {
-                        error!(
-                            "Failed to get connection from pool for server `{}`: {}",
-                            server.address, e
-                        );
-                        self.connection_registry.mark_unavailable(&server);
-                        continue;
-                    }
-                }
-            } else {
-                // We couldn't find a connection manager for the server, it was probably marked unavailable
-                error!(
-                    "No connection manager available for router `{}` in the registry",
-                    server.address
-                );
-                return Err(Error::ServerUnavailableError(format!(
-                    "No connection manager available for router `{}` in the registry",
-                    server.address
-                )));
+        loop {
+            // we loop here until we get a connection. If the routing table is empty, we force a refresh
+            if self.connection_registry.connections.is_empty() {
+                // the first time we need to wait until we get the routing table
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                continue;
             }
+
+            while let Some(server) = match op {
+                Operation::Write => self.select_writer(),
+                _ => self.select_reader(),
+            } {
+                debug!("requesting connection for server: {:?}", server);
+                if let Some(pool) = self.connection_registry.get_pool(&server) {
+                    match pool.get().await {
+                        Ok(connection) => return Ok(connection),
+                        Err(e) => {
+                            error!(
+                                "Failed to get connection from pool for server `{}`: {}",
+                                server.address, e
+                            );
+                            self.connection_registry.mark_unavailable(&server);
+                            continue;
+                        }
+                    }
+                } else {
+                    // We couldn't find a connection manager for the server, it was probably marked unavailable
+                    error!(
+                        "No connection manager available for router `{}` in the registry",
+                        server.address
+                    );
+                    return Err(Error::ServerUnavailableError(format!(
+                        "No connection manager available for router `{}` in the registry",
+                        server.address
+                    )));
+                }
+            }
+            debug!("Routing table is empty for requested {op} operation, forcing refresh");
+            self.channel
+                .send(RegistryCommand::Refresh(
+                    self.bookmarks.lock().await.clone(),
+                ))
+                .await
+                .map_err(|e| {
+                    error!("Failed to send refresh command to registry: {}", e);
+                    Error::RoutingTableRefreshFailed(
+                        "Failed to send refresh command to registry".to_string(),
+                    )
+                })?;
+            // table is not empty, but we couldn't get a connection, so we throw an error
+            break Err(Error::ServerUnavailableError(format!(
+                "No server available for {op} operation"
+            )));
         }
-        debug!("Routing table is empty for requested {op} operation, forcing refresh");
-        self.channel
-            .send(RegistryCommand::Refresh)
-            .await
-            .map_err(|e| {
-                error!("Failed to send refresh command to registry: {}", e);
-                Error::RoutingTableRefreshFailed(
-                    "Failed to send refresh command to registry".to_string(),
-                )
-            })?;
-        Err(Error::ServerUnavailableError(format!(
-            "No server available for {op} operation"
-        )))
     }
 
     pub(crate) fn backoff(&self) -> ExponentialBackoff {
@@ -111,15 +122,10 @@ impl RoutedConnectionManager {
     }
 
     #[allow(dead_code)]
-    pub(crate) async fn add_bookmark(&self, bookmark: String) {
-        self.bookmarks.lock().await.push(bookmark);
-    }
-
-    #[allow(dead_code)]
-    pub(crate) async fn remove_bookmark(&self, bookmark: &str) {
-        let mut bookmarks = self.bookmarks.lock().await;
-        if let Some(index) = bookmarks.iter().position(|b| b == bookmark) {
-            bookmarks.remove(index);
+    pub(crate) async fn add_bookmark(&self, bookmark: &str) {
+        let mut guard = self.bookmarks.lock().await;
+        if !guard.contains(&bookmark.to_string()) {
+            guard.push(bookmark.to_string());
         }
     }
 

--- a/lib/src/routing/routing_table_provider.rs
+++ b/lib/src/routing/routing_table_provider.rs
@@ -8,6 +8,7 @@ pub(crate) trait RoutingTableProvider: Send + Sync {
     fn fetch_routing_table(
         &self,
         config: &Config,
+        bookmarks: &[String],
     ) -> Pin<Box<dyn Future<Output = Result<RoutingTable, Error>> + Send>>;
 }
 
@@ -17,8 +18,10 @@ impl RoutingTableProvider for ClusterRoutingTableProvider {
     fn fetch_routing_table(
         &self,
         config: &Config,
+        bookmarks: &[String],
     ) -> Pin<Box<dyn Future<Output = Result<RoutingTable, Error>> + Send>> {
         let config = config.clone();
+        let bookmarks = bookmarks.to_vec();
         Box::pin(async move {
             let info = ConnectionInfo::new(
                 &config.uri,
@@ -27,7 +30,7 @@ impl RoutingTableProvider for ClusterRoutingTableProvider {
                 &config.tls_config,
             )?;
             let mut connection = Connection::new(&info).await?;
-            let mut builder = RouteBuilder::new(info.routing, vec![]);
+            let mut builder = RouteBuilder::new(info.routing, bookmarks);
             if let Some(db) = config.db.clone() {
                 builder = builder.with_db(db);
             }

--- a/lib/src/summary.rs
+++ b/lib/src/summary.rs
@@ -1,9 +1,10 @@
-use std::{fmt, time::Duration};
-
+#[cfg(feature = "unstable-bolt-protocol-impl-v2")]
+use crate::bookmarks::Bookmark;
 use serde::{
     de::{self, Visitor},
     Deserialize,
 };
+use std::{fmt, time::Duration};
 
 #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
 type MapKey = String;
@@ -190,6 +191,13 @@ impl ResultSummary {
 
     pub(crate) fn set_t_first(&mut self, t_first: i64) {
         self.t_first = u64::try_from(t_first).ok();
+    }
+}
+
+#[cfg(feature = "unstable-bolt-protocol-impl-v2")]
+impl Bookmark for ResultSummary {
+    fn get_bookmark(&self) -> Option<&str> {
+        self.bookmark.as_deref()
     }
 }
 

--- a/lib/src/txn.rs
+++ b/lib/src/txn.rs
@@ -145,7 +145,7 @@ impl Txn {
     pub async fn commit(mut self) -> Result<()> {
         let commit = BoltRequest::commit();
         match self.connection.send_recv(commit).await? {
-            BoltResponse::Success(_) => Ok(None),
+            BoltResponse::Success(_) => Ok(()),
             msg => Err(msg.into_error("COMMIT")),
         }
     }

--- a/lib/src/txn.rs
+++ b/lib/src/txn.rs
@@ -1,27 +1,32 @@
+#[cfg(not(feature = "unstable-bolt-protocol-impl-v2"))]
+use crate::messages::{BoltRequest, BoltResponse};
 #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
-use crate::bolt::{Commit, Rollback, Summary};
+use {
+    crate::bolt::{Begin, Commit, Rollback, Summary},
+    crate::bookmarks::Bookmark,
+    log::debug,
+};
+
 use crate::{
-    config::Database,
-    errors::Result,
-    messages::{BoltRequest, BoltResponse},
-    pool::ManagedConnection,
-    query::Query,
-    stream::RowStream,
+    config::Database, errors::Result, pool::ManagedConnection, query::Query, stream::RowStream,
     Operation, RunResult,
 };
 
 /// A handle which is used to control a transaction, created as a result of [`crate::Graph::start_txn`]
 ///
-/// When a transation is started, a dedicated connection is resered and moved into the handle which
+/// When a transaction is started, a dedicated connection is reserved and moved into the handle which
 /// will be released to the connection pool when the [`Txn`] handle is dropped.
 pub struct Txn {
     db: Option<Database>,
     fetch_size: usize,
     connection: ManagedConnection,
     operation: Operation,
+    #[allow(dead_code)]
+    bookmark: Option<String>,
 }
 
 impl Txn {
+    #[cfg(not(feature = "unstable-bolt-protocol-impl-v2"))]
     pub(crate) async fn new(
         db: Option<Database>,
         fetch_size: usize,
@@ -35,8 +40,34 @@ impl Txn {
                 fetch_size,
                 connection,
                 operation,
+                bookmark: None,
             }),
             msg => Err(msg.into_error("BEGIN")),
+        }
+    }
+
+    #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
+    pub(crate) async fn new(
+        db: Option<Database>,
+        fetch_size: usize,
+        mut connection: ManagedConnection,
+        operation: Operation,
+        bookmarks: &[String],
+    ) -> Result<Self> {
+        debug!("Starting transaction with bookmarks: {:?}", bookmarks);
+        let begin = Begin::builder(db.as_deref())
+            .with_bookmarks(bookmarks.to_vec())
+            .build(connection.version());
+        match connection.send_recv_as(begin).await? {
+            Summary::Success(response) => Ok(Txn {
+                db: response.metadata.db.or(db),
+                fetch_size,
+                connection,
+                operation,
+                bookmark: None,
+            }),
+            Summary::Ignored => Err(crate::errors::Error::Ignored("Failed to start transaction")),
+            Summary::Failure(failure) => Err(failure.into_error()),
         }
     }
 
@@ -51,6 +82,7 @@ impl Txn {
         for query in queries {
             let summary = self.run(query.into()).await?;
             counters += summary.stats();
+            self.save_bookmark_state(&summary);
         }
         Ok(counters)
     }
@@ -80,7 +112,14 @@ impl Txn {
                 Operation::Write => "w",
             },
         );
-        query.run(&mut self.connection).await
+        match query.run(&mut self.connection).await {
+            Ok(result) => {
+                #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
+                self.save_bookmark_state(&result);
+                Ok(result)
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// Executes a query and returns a [`RowStream`]
@@ -102,12 +141,12 @@ impl Txn {
     }
 
     /// Commits the transaction in progress
-    pub async fn commit(mut self) -> Result<()> {
+    pub async fn commit(mut self) -> Result<Option<String>> {
         #[cfg(not(feature = "unstable-bolt-protocol-impl-v2"))]
         {
             let commit = BoltRequest::commit();
             match self.connection.send_recv(commit).await? {
-                BoltResponse::Success(_) => Ok(()),
+                BoltResponse::Success(_) => Ok(None),
                 msg => Err(msg.into_error("COMMIT")),
             }
         }
@@ -115,7 +154,10 @@ impl Txn {
         #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
         {
             match self.connection.send_recv_as(Commit).await? {
-                Summary::Success(_) => Ok(()),
+                Summary::Success(resp) => {
+                    self.save_bookmark_state(&resp.metadata);
+                    Ok(self.bookmark)
+                }
                 msg => Err(msg.into_error("COMMIT")),
             }
         }
@@ -143,6 +185,20 @@ impl Txn {
 
     pub fn handle(&mut self) -> &mut impl TransactionHandle {
         self
+    }
+
+    #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
+    pub fn last_bookmark(&self) -> Option<&str> {
+        self.bookmark.as_deref()
+    }
+
+    #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
+    fn save_bookmark_state(&mut self, summary: &impl Bookmark) {
+        if let Some(bookmark) = summary.get_bookmark() {
+            self.bookmark = Some(bookmark.to_string());
+        } else {
+            self.bookmark = None;
+        }
     }
 }
 

--- a/lib/tests/bookmarks.rs
+++ b/lib/tests/bookmarks.rs
@@ -1,0 +1,11 @@
+use neo4rs::*;
+
+mod container;
+
+#[tokio::test]
+async fn transactions() {
+    let neo4j = container::Neo4jContainer::new().await;
+    let graph = neo4j.graph();
+
+    include!("../include/bookmarks.rs");
+}

--- a/lib/tests/bookmarks.rs
+++ b/lib/tests/bookmarks.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "unstable-bolt-protocol-impl-v2")]
 use neo4rs::*;
 
 mod container;


### PR DESCRIPTION
This PR aims to add support for bookmarks in transactions. It also collects bookmarks used in a routed manager and sends them when requesting a new routing table. The list of collected bookmarks is cleared up every time a READ operation returns no bookmarks (that should mean the state of the cluster is consistent).
The bookmarks are sent in the BEGIN message and retrieved from the COMMIT message.

## Doubts
I read somewhere that the command HELLO can also contain bookmarks, but the documentation [does not say a thing about it](https://neo4j.com/docs/bolt/current/bolt/message/#messages-hello).

Bonus: While implementing this feature, I found a problem when getting a connection in a routed environment, caused by a synchronization problem between the manager and the thread fetching the routing table.

## Changes
### Transaction Handling Updates:
* Added a new `Begin` request type with associated metadata and builder pattern for constructing instances. (`lib/src/bolt/request/begin.rs`)
* Modified the `Commit` request type to include a `CommitResponse` that handles bookmarks. (`lib/src/bolt/request/commit.rs`) [[1]](diffhunk://#diff-4130c39c76f9bd2597fb878f4c73e514b35669cb63d8bdf78d9df952ff005092L1-R19) [[2]](diffhunk://#diff-4130c39c76f9bd2597fb878f4c73e514b35669cb63d8bdf78d9df952ff005092L18-R36) [[3]](diffhunk://#diff-4130c39c76f9bd2597fb878f4c73e514b35669cb63d8bdf78d9df952ff005092R48-R60)
* Updated the `Graph` struct to support starting transactions with bookmarks and to handle bookmarks in query execution results. (`lib/src/graph.rs`) [[1]](diffhunk://#diff-03389443cc0dc82cad314d36c595350f8f4fe58b85abdf4e231e304ec426d35cL126-R126) [[2]](diffhunk://#diff-03389443cc0dc82cad314d36c595350f8f4fe58b85abdf4e231e304ec426d35cL136-R145) [[3]](diffhunk://#diff-03389443cc0dc82cad314d36c595350f8f4fe58b85abdf4e231e304ec426d35cL147-R175) [[4]](diffhunk://#diff-03389443cc0dc82cad314d36c595350f8f4fe58b85abdf4e231e304ec426d35cL207-R228) [[5]](diffhunk://#diff-03389443cc0dc82cad314d36c595350f8f4fe58b85abdf4e231e304ec426d35cL216-R237) [[6]](diffhunk://#diff-03389443cc0dc82cad314d36c595350f8f4fe58b85abdf4e231e304ec426d35cL231-R269)

### Routing Mechanism Updates:
* Added a new `Begin` request type to the `bolt/request/mod.rs` module. (`lib/src/bolt/request/mod.rs`) [[1]](diffhunk://#diff-6677bc917d82999dd885cf9af6bece2894aa0b051861707c0f1f5c2bfe261110R1) [[2]](diffhunk://#diff-6677bc917d82999dd885cf9af6bece2894aa0b051861707c0f1f5c2bfe261110R12)
* Modified the `Route` request type to remove lifetime parameters and updated serialization logic. (`lib/src/bolt/request/route.rs`) [[1]](diffhunk://#diff-35d47da393cafe11ddf69def749ae403856277bd35ae2165c1295d188f083e77L2-R13) [[2]](diffhunk://#diff-35d47da393cafe11ddf69def749ae403856277bd35ae2165c1295d188f083e77L35-R35) [[3]](diffhunk://#diff-35d47da393cafe11ddf69def749ae403856277bd35ae2165c1295d188f083e77L73-R80) [[4]](diffhunk://#diff-35d47da393cafe11ddf69def749ae403856277bd35ae2165c1295d188f083e77L103-R103) [[5]](diffhunk://#diff-35d47da393cafe11ddf69def749ae403856277bd35ae2165c1295d188f083e77L125-R125) [[6]](diffhunk://#diff-35d47da393cafe11ddf69def749ae403856277bd35ae2165c1295d188f083e77L151-R151)

### Miscellaneous:
* Introduced a `Bookmark` trait to standardize bookmark handling across different response types. (`lib/src/bookmarks.rs`)
* Updated the `Connection` struct to support the new `Route` request type without lifetime parameters. (`lib/src/connection.rs`)