### PR TITLE
Optional backoff

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -509,7 +509,7 @@ mod types;
 mod version;
 
 pub use crate::auth::ClientCertificate;
-pub use crate::config::{Config, ConfigBuilder, Database};
+pub use crate::config::{BackoffConfig, BackoffConfigBuilder, Config, ConfigBuilder, Database};
 pub use crate::errors::{
     Error, Neo4jClientErrorKind, Neo4jError, Neo4jErrorKind, Neo4jSecurityErrorKind, Result,
 };

--- a/lib/src/pool.rs
+++ b/lib/src/pool.rs
@@ -1,6 +1,5 @@
-use std::time::Duration;
-
 use crate::auth::ConnectionTLSConfig;
+use crate::config::BackoffConfig;
 use crate::{
     config::Config,
     connection::{Connection, ConnectionInfo},
@@ -15,7 +14,7 @@ pub type ManagedConnection = Object<ConnectionManager>;
 
 pub struct ConnectionManager {
     info: ConnectionInfo,
-    backoff: ExponentialBuilder,
+    backoff: Option<ExponentialBuilder>,
 }
 
 impl ConnectionManager {
@@ -24,25 +23,16 @@ impl ConnectionManager {
         user: &str,
         password: &str,
         tls_config: &ConnectionTLSConfig,
+        backoff_config: Option<&BackoffConfig>,
     ) -> Result<Self> {
         let info = ConnectionInfo::new(uri, user, password, tls_config)?;
-        let backoff = backoff();
+        let backoff = backoff_config.map(|backoff_config| backoff_config.to_exponential_builder());
         Ok(ConnectionManager { info, backoff })
     }
 
-    pub fn backoff(&self) -> ExponentialBuilder {
-        self.backoff
+    pub fn backoff(&self) -> Option<ExponentialBuilder> {
+        self.backoff.clone()
     }
-}
-
-pub(crate) fn backoff() -> ExponentialBuilder {
-    ExponentialBuilder::new()
-        .with_jitter()
-        .with_factor(2.0)
-        .without_max_times()
-        .with_min_delay(Duration::from_millis(1))
-        .with_max_delay(Duration::from_secs(10))
-        .with_total_delay(Some(Duration::from_secs(60)))
 }
 
 impl Manager for ConnectionManager {
@@ -66,6 +56,7 @@ pub fn create_pool(config: &Config) -> Result<ConnectionPool> {
         &config.user,
         &config.password,
         &config.tls_config,
+        config.backoff.as_ref(),
     )?;
     info!(
         "creating connection pool for node {} with max size {}",

--- a/lib/src/pool.rs
+++ b/lib/src/pool.rs
@@ -31,7 +31,7 @@ impl ConnectionManager {
     }
 
     pub fn backoff(&self) -> Option<ExponentialBuilder> {
-        self.backoff.clone()
+        self.backoff
     }
 }
 

--- a/lib/src/routing/connection_registry.rs
+++ b/lib/src/routing/connection_registry.rs
@@ -418,6 +418,7 @@ mod tests {
             db: None,
             fetch_size: 200,
             tls_config: ConnectionTLSConfig::None,
+            backoff: None,
         };
         let registry = Arc::new(ConnectionRegistry::default());
         let ttl = refresh_all_routing_tables(
@@ -539,6 +540,7 @@ mod tests {
             db: None,
             fetch_size: 200,
             tls_config: ConnectionTLSConfig::None,
+            backoff: None,
         };
         let registry = Arc::new(ConnectionRegistry::default());
         // get registry for db1 amd refresh routing table

--- a/lib/src/routing/connection_registry.rs
+++ b/lib/src/routing/connection_registry.rs
@@ -176,6 +176,7 @@ async fn refresh_routing_table(
             server.clone(),
             create_pool(&Config {
                 uri,
+                backoff: None,
                 ..config.clone()
             })?,
         );

--- a/lib/src/routing/routed_connection_manager.rs
+++ b/lib/src/routing/routed_connection_manager.rs
@@ -1,4 +1,3 @@
-use crate::config::BackoffConfig;
 use crate::pool::ManagedConnection;
 use crate::routing::connection_registry::{
     start_background_updater, BoltServer, ConnectionRegistry, RegistryCommand,
@@ -28,6 +27,9 @@ const ROUTING_TABLE_MAX_WAIT_TIME_MS: i32 = 5000;
 
 impl RoutedConnectionManager {
     pub fn new(config: &Config, provider: Arc<dyn RoutingTableProvider>) -> Result<Self, Error> {
+        // backoff config should be set to None here, since the routing table updater will handle retries
+        // We could provide some configuration to "force" the retry mechanism in a clustered env,
+        // but for now we will turn it off
         let backoff = config
             .backoff
             .clone()


### PR DESCRIPTION
A PR to make backoff optional (and disable it for routed connections). It introduces a new `BackoffConfig` structure to provide configurable retry logic for database connections. It replaces the previously hardcoded exponential backoff logic with a more flexible and customizable approach. The changes include updates to configuration structures, builders, and relevant tests, as well as modifications to integrate the new backoff logic into connection management and retry mechanisms.

**NOTE**: The PR is in DRAFT since it is still untested.

### New Backoff Configuration:

* Added `BackoffConfig` struct with fields for `multiplier`, `min_delay_ms`, `max_delay_ms`, and `total_delay_ms`, along with a default implementation. This struct allows customization of backoff behavior. (`lib/src/config.rs`, [lib/src/config.rsR71-R151](diffhunk://#diff-c602a3fda3470e4b92b2555f68a74c696620dabed0f002fff7bebb9302c72a66R71-R151))
* Implemented `BackoffConfigBuilder` to facilitate the construction of `BackoffConfig` instances with optional parameters. (`lib/src/config.rs`, [lib/src/config.rsR71-R151](diffhunk://#diff-c602a3fda3470e4b92b2555f68a74c696620dabed0f002fff7bebb9302c72a66R71-R151))

### Integration with Configuration:

* Updated `Config` and `ConfigBuilder` to include an optional `backoff` field, allowing backoff settings to be specified during configuration. (`lib/src/config.rs`, [[1]](diffhunk://#diff-c602a3fda3470e4b92b2555f68a74c696620dabed0f002fff7bebb9302c72a66R162) [[2]](diffhunk://#diff-c602a3fda3470e4b92b2555f68a74c696620dabed0f002fff7bebb9302c72a66R183)
* Adjusted the default `ConfigBuilder` to include a default `BackoffConfig`. (`lib/src/config.rs`, [lib/src/config.rsR286](diffhunk://#diff-c602a3fda3470e4b92b2555f68a74c696620dabed0f002fff7bebb9302c72a66R286))

### Connection Management:

* Modified `ConnectionManager` to accept an optional `BackoffConfig` and use it to generate an `ExponentialBuilder` for retry logic. (`lib/src/pool.rs`, [[1]](diffhunk://#diff-714cd989ac998bedc8a1e5d06be0bd5fa442ee7ec7a5e6b83d8bd30e80a077f9L18-R17) [[2]](diffhunk://#diff-714cd989ac998bedc8a1e5d06be0bd5fa442ee7ec7a5e6b83d8bd30e80a077f9R26-L47)
* Updated `create_pool` to pass the `backoff` configuration when creating a connection manager. (`lib/src/pool.rs`, [lib/src/pool.rsR59](diffhunk://#diff-714cd989ac998bedc8a1e5d06be0bd5fa442ee7ec7a5e6b83d8bd30e80a077f9R59))

### Retry Logic Updates:

* Updated retry logic in `Graph` and `RoutedConnectionManager` to use the optional `BackoffConfig`. If no backoff is provided, retries are skipped. (`lib/src/graph.rs`, [[1]](diffhunk://#diff-03389443cc0dc82cad314d36c595350f8f4fe58b85abdf4e231e304ec426d35cL49-R49) [[2]](diffhunk://#diff-03389443cc0dc82cad314d36c595350f8f4fe58b85abdf4e231e304ec426d35cL236-R246) [[3]](diffhunk://#diff-03389443cc0dc82cad314d36c595350f8f4fe58b85abdf4e231e304ec426d35cL334-R348); `lib/src/routing/routed_connection_manager.rs`, [[4]](diffhunk://#diff-3c00a2cb1f99c251ffc2499515abb0dabb102d69e4f318cdf6c970ff9ab195a2L22-R36) [[5]](diffhunk://#diff-3c00a2cb1f99c251ffc2499515abb0dabb102d69e4f318cdf6c970ff9ab195a2L134-R140)

### Tests:

* Enhanced tests to validate the behavior of `BackoffConfig` and its integration into `Config` and `ConfigBuilder`. Tests now check for proper handling of default and custom backoff configurations. (`lib/src/config.rs`, [[1]](diffhunk://#diff-c602a3fda3470e4b92b2555f68a74c696620dabed0f002fff7bebb9302c72a66R304) [[2]](diffhunk://#diff-c602a3fda3470e4b92b2555f68a74c696620dabed0f002fff7bebb9302c72a66R332-R333) [[3]](diffhunk://#diff-c602a3fda3470e4b92b2555f68a74c696620dabed0f002fff7bebb9302c72a66R343-R345) [[4]](diffhunk://#diff-c602a3fda3470e4b92b2555f68a74c696620dabed0f002fff7bebb9302c72a66R355-R356)
* Adjusted tests in `routing/connection_registry.rs` to account for the optional `backoff` field. (`lib/src/routing/connection_registry.rs`, [[1]](diffhunk://#diff-bf3db30debec7ef508e0cc7e48e8def05d39e53c7ed7666a411e06893ecfbb79R422) [[2]](diffhunk://#diff-bf3db30debec7ef508e0cc7e48e8def05d39e53c7ed7666a411e06893ecfbb79R544)