### PR TITLE
feat: support MutualTLS.

### DIFF
--- a/lib/src/auth/mod.rs
+++ b/lib/src/auth/mod.rs
@@ -5,6 +5,7 @@ pub enum ConnectionTLSConfig {
     None,
     ClientCACertificate(ClientCertificate),
     NoSSLValidation,
+    MutualTLS(MutualTLS),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -16,6 +17,27 @@ impl ClientCertificate {
     pub fn new(path: impl AsRef<Path>) -> Self {
         ClientCertificate {
             cert_file: path.as_ref().to_path_buf(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MutualTLS {
+    pub(crate) cert_file: Option<PathBuf>,
+    pub(crate) client_cert: PathBuf,
+    pub(crate) client_key: PathBuf,
+}
+
+impl MutualTLS {
+    pub fn new(
+        cert_file: Option<impl AsRef<Path>>,
+        client_cert: impl AsRef<Path>,
+        client_key: impl AsRef<Path>,
+    ) -> Self {
+        MutualTLS {
+            cert_file: cert_file.map(|p| p.as_ref().to_path_buf()),
+            client_cert: client_cert.as_ref().to_path_buf(),
+            client_key: client_key.as_ref().to_path_buf(),
         }
     }
 }

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -1,4 +1,4 @@
-use crate::auth::{ClientCertificate, ConnectionTLSConfig};
+use crate::auth::{ClientCertificate, ConnectionTLSConfig, MutualTLS};
 use crate::errors::{Error, Result};
 #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
 use serde::{Deserialize, Deserializer, Serialize};
@@ -156,6 +156,18 @@ impl ConfigBuilder {
     pub fn with_client_certificate(mut self, client_cert: impl AsRef<Path>) -> Self {
         self.tls_config =
             ConnectionTLSConfig::ClientCACertificate(ClientCertificate::new(client_cert));
+        self
+    }
+
+    //Used for bidirectional authentication
+    pub fn with_mutual_tls_validation(
+        mut self,
+        client_cert: Option<impl AsRef<Path>>,
+        ssl_cert: impl AsRef<Path>,
+        ssl_key: impl AsRef<Path>,
+    ) -> Self {
+        self.tls_config =
+            ConnectionTLSConfig::MutualTLS(MutualTLS::new(client_cert, ssl_cert, ssl_key));
         self
     }
 

--- a/lib/src/connection.rs
+++ b/lib/src/connection.rs
@@ -402,7 +402,7 @@ impl ConnectionInfo {
                 // do not apply validation if using a self-signed certificate,as the documentation suggests
                 let config = if !validation {
                     match tls_config {
-                        ConnectionTLSConfig::MutualTLS(_) => &tls_config,
+                        ConnectionTLSConfig::MutualTLS(_) => tls_config,
                         _ => &ConnectionTLSConfig::NoSSLValidation,
                     }
                 } else {
@@ -490,19 +490,19 @@ impl ConnectionInfo {
                 let keys = rustls_pemfile::private_key(&mut key_reader);
                 let keys = keys?.unwrap();
                 if mutual.cert_file.is_some() {
-                    let root_cert_file = File::open((&mutual).cert_file.as_ref().unwrap())?;
+                    let root_cert_file = File::open(mutual.cert_file.as_ref().unwrap())?;
                     let mut root_reader = BufReader::new(root_cert_file);
                     let root_certs = rustls_pemfile::certs(&mut root_reader).flatten();
                     root_cert_store.add_parsable_certificates(root_certs);
                     builder
                         .with_root_certificates(root_cert_store)
                         .with_client_auth_cert(cert_certs.collect(), keys)
-                        .map_err(|e| Error::ConnectionError)?
+                        .map_err(|_e| Error::ConnectionError)?
                 } else {
                     builder
                         .with_root_certificates(RootCertStore::empty())
                         .with_client_auth_cert(cert_certs.collect(), keys)
-                        .map_err(|e| Error::ConnectionError)?
+                        .map_err(|_e| Error::ConnectionError)?
                 }
             }
         };


### PR DESCRIPTION
Provided mutual authentication support。
```rust
  //Used for bidirectional authentication
    pub fn with_mutual_tls_validation(
        mut self,
        client_cert: Option<impl AsRef<Path>>,
        ssl_cert: impl AsRef<Path>,
        ssl_key: impl AsRef<Path>,
    ) -> Self {
        self.tls_config =
            ConnectionTLSConfig::MutualTLS(MutualTLS::new(client_cert, ssl_cert, ssl_key));
        self
    }
```
https://github.com/neo4j-labs/neo4rs/issues/247