### PR TITLE
return ResultSummary in 'run'

### DIFF
--- a/lib/src/graph.rs
+++ b/lib/src/graph.rs
@@ -192,6 +192,13 @@ impl Graph {
     /// Use [`Graph::run`] for cases where you just want a write operation
     ///
     /// use [`Graph::execute`] when you are interested in the result stream
+    #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
+    pub async fn run(&self, q: impl Into<Query>) -> Result<ResultSummary> {
+        self.impl_run_on(self.config.db.clone(), q.into(), Operation::Write)
+            .await
+    }
+
+    #[cfg(not(feature = "unstable-bolt-protocol-impl-v2"))]
     pub async fn run(&self, q: impl Into<Query>) -> Result<RunResult> {
         self.impl_run_on(self.config.db.clone(), q.into(), Operation::Write)
             .await


### PR DESCRIPTION
Similar to [run_on](https://docs.rs/neo4rs/latest/neo4rs/struct.Graph.html#method.run_on), when the feature flag `unstable-bolt-protocol-impl-v2` is enabled, `run` can return a `ResultSummary`.

If it was intended to still return `()`, please just close this 😄