### PR TITLE
Replace Dashmap with scc

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -33,7 +33,6 @@ backon = { version = "1.5.1", default-features = false, features = [
 ] }
 bytes = { version = "1.5.0", features = ["serde"] }
 chrono-tz = "0.10.0"
-dashmap = "6.1.0"
 delegate = "0.13.0"
 futures = { version = "0.3.0" }
 log = "0.4.0"
@@ -43,6 +42,7 @@ pastey = "0.1.0"
 pin-project-lite = "0.2.9"
 rustls-native-certs = "0.7.3"
 rustls-pemfile = "2.1.2"
+scc = "3.0.2"
 serde = { version = "1.0.185", features = ["derive"] }    # TODO: eliminate derive
 serde_json = { version = "1.0.0", optional = true }
 thiserror = "1.0.7"


### PR DESCRIPTION
This PR replaces the Dashmap crate with SCC.
The change was needed since the Dashmap can leave a dangling lock when getting a connection pool from the router map, causing a deadlock on the client, which makes it unable to get a new connection.

NOTE: opening in draft since the PR is currently under testing. 