### PR TITLE
Introduce session

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
   release:
-    types: [published]
+    types: [ published ]
   merge_group:
   workflow_dispatch:
     inputs:
@@ -23,7 +23,7 @@ on:
 env:
   RUST_LOG: debug
   CARGO_TERM_COLOR: always
-  MSRV: 1.75.0
+  MSRV: 1.81.0
   HACK: hack --package neo4rs --each-feature --exclude-features unstable-serde-packstream-format,unstable-bolt-protocol-impl-v2,unstable-result-summary
 
 jobs:
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macOS-latest, ubuntu-latest]
+        os: [ windows-latest, macOS-latest, ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
 
@@ -140,7 +140,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        neo4j: ["5", "4.4"]
+        neo4j: [ "5", "4.4" ]
     runs-on: ubuntu-latest
     services:
       neo4j:
@@ -217,7 +217,7 @@ jobs:
 
   release:
     name: Release
-    needs: [check, fmt, clippy, unit-tests, integration-tests, msrv]
+    needs: [ check, fmt, clippy, unit-tests, integration-tests, msrv ]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,7 +23,7 @@ on:
 env:
   RUST_LOG: debug
   CARGO_TERM_COLOR: always
-  MSRV: 1.81.0
+  MSRV: 1.75.0
   HACK: hack --package neo4rs --each-feature --exclude-features unstable-serde-packstream-format,unstable-bolt-protocol-impl-v2,unstable-result-summary
 
 jobs:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -20,7 +20,7 @@ on:
 
 env:
   RUSTUP_TOOLCHAIN: stable
-  MSRV: 1.81.0
+  MSRV: 1.75.0
 
 jobs:
   make-release-pr:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -20,7 +20,7 @@ on:
 
 env:
   RUSTUP_TOOLCHAIN: stable
-  MSRV: 1.75.0
+  MSRV: 1.81.0
 
 jobs:
   make-release-pr:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Neo4rs [![CI Status][ci-badge]][ci-url]  [![Crates.io][crates-badge]][crates-url]
 
 [ci-badge]: https://github.com/neo4j-labs/neo4rs/actions/workflows/checks.yml/badge.svg
+
 [ci-url]: https://github.com/neo4j-labs/neo4rs
+
 [crates-badge]: https://img.shields.io/crates/v/neo4rs.svg?style=shield
+
 [crates-url]: https://crates.io/crates/neo4rs
+
 [docs-badge]: https://img.shields.io/badge/docs-latest-blue.svg?style=shield
+
 [docs-url]: https://docs.rs/neo4rs
 
 `neo4rs` is a driver for the [Neo4j](https://neo4j.com/) graph database, written in Rust.
@@ -12,53 +17,53 @@
 `neo4rs` implements the [bolt specification](https://neo4j.com/docs/bolt/current/bolt/message/#messages-summary-41)
 
 This driver is compatible with Neo4j version 5.x and 4.4.
-Only the latest 5.x version is supported, following the [Neo4j Version support policy](https://neo4j.com/developer/kb/neo4j-supported-versions/).
+Only the latest 5.x version is supported, following
+the [Neo4j Version support policy](https://neo4j.com/developer/kb/neo4j-supported-versions/).
 
 ## API Documentation: [![Docs.rs][docs-badge]][docs-url]
 
 ## [Getting Started](https://neo4j.com/docs/getting-started/languages-guides/community-drivers/#neo4j-rust)
 
-
 ## Example
 
 ```rust
     // concurrent queries
-    let uri = "127.0.0.1:7687";
-    let user = "neo4j";
-    let pass = "neo";
-    let graph = Graph::new(&uri, user, pass).unwrap();
-    for _ in 1..=42 {
-        let graph = graph.clone();
-        tokio::spawn(async move {
-            let mut result = graph.execute(
-               query("MATCH (p:Person {name: $name}) RETURN p").param("name", "Mark")
-            ).await.unwrap();
-            while let Some(row) = result.next().await.unwrap() {
-                let node: Node = row.get("p").unwrap();
-                let name: String = node.get("name").unwrap();
-                println!("{}", name);
-            }
-        });
-    }
+let uri = "127.0.0.1:7687";
+let user = "neo4j";
+let pass = "neo";
+let graph = Graph::new( & uri, user, pass).unwrap();
+for _ in 1..=42 {
+let graph = graph.clone();
+tokio::spawn(async move {
+let mut result = graph.execute(
+query("MATCH (p:Person {name: $name}) RETURN p").param("name", "Mark")
+).await.unwrap();
+while let Some(row) = result.next().await.unwrap() {
+let node: Node = row.get("p").unwrap();
+let name: String = node.get("name").unwrap();
+println ! ("{}", name);
+}
+});
+}
 
-    //Transactions
-    let mut txn = graph.start_txn().await.unwrap();
-    txn.run_queries([
-        "CREATE (p:Person {name: 'mark'})",
-        "CREATE (p:Person {name: 'jake'})",
-        "CREATE (p:Person {name: 'luke'})",
-    ])
-    .await
-    .unwrap();
-    txn.commit().await.unwrap(); //or txn.rollback().await.unwrap();
+//Transactions
+let mut txn = graph.start_txn().await.unwrap();
+txn.run_queries([
+"CREATE (p:Person {name: 'mark'})",
+"CREATE (p:Person {name: 'jake'})",
+"CREATE (p:Person {name: 'luke'})",
+])
+.await
+.unwrap();
+txn.commit().await.unwrap(); //or txn.rollback().await.unwrap();
 ```
 
 ## MSRV
 
-The crate has a minimum supported Rust version (MSRV) of `1.75.0` as of 0.9.x.
+The crate has a minimum supported Rust version (MSRV) of `1.81.0` as of 0.9.x.
 The version [0.8.x](https://crates.io/crates/neo4rs/0.8.0) has an MSRV of `1.63.0`
 
-A change in the MSRV in *not* considered a breaking change.
+A change in the MSRV is *not* considered a breaking change.
 For versions past 1.0.0, a change in the MSRV can be done in a minor version increment (1.1.3 -> 1.2.0)
 for versions before 1.0.0, a change in the MSRV can be done in a patch version increment (0.1.3 -> 0.1.4).
 
@@ -67,10 +72,11 @@ for versions before 1.0.0, a change in the MSRV can be done in a patch version i
 > [!IMPORTANT]
 > This driver is a work in progress, and not all features are implemented yet.
 
-Only Bolt protocol versions 4.0 and 4.1 are supported.
+Only Bolt protocol versions 4.0, 4.1, 4.2 and 4.3 are supported.
 Support for later versions is planned and in progress.
 
-This means, that certain features like bookmarks or element IDs are not supported yet.
+This means, that certain features like element IDs are not supported yet.
+Features like routing, sessions and bookmarks are supported by turning on the feature `unstable-bolt-protocol-impl-v2`.
 
 ## Development
 
@@ -95,16 +101,20 @@ The tests will use the official `neo4j` docker image, with the provided version 
 You might run into panics or test failures with the message 'failed to start container'.
 In that case, try to pull the image first before running the tests with `docker pull neo4j:$NEO4J_VERSION_TAG`.
 
-This could happen if you are on a machine with an architecture that is not supported by the image, e.g. `arm64` like the Apple silicon Macs.
+This could happen if you are on a machine with an architecture that is not supported by the image, e.g. `arm64` like the
+Apple silicon Macs.
 In that case, pulling the image will fail with a message like 'no matching manifest for linux/arm64/v8'.
-You need to use the `--platform` flag to pull the image for a different architecture, e.g. `docker pull --platform linux/amd64 neo4j:$NEO4J_VERSION_TAG`.
-There is an experimental option in docker to use Rosetta to run those images, so that tests don't take forever to run (please check the docker documentation).
+You need to use the `--platform` flag to pull the image for a different architecture, e.g.
+`docker pull --platform linux/amd64 neo4j:$NEO4J_VERSION_TAG`.
+There is an experimental option in docker to use Rosetta to run those images, so that tests don't take forever to run (
+please check the docker documentation).
 
 You could also use a newer neo4j version like `4.4` instead, which has support for `arm64` architecture.
 
 ##### Using an existing Neo4j instance
 
-To run the tests with an existing Neo4j instance, you need to have the `NEO4J_TEST_URI` environment variable set to the connection string, e.g. `neo4j+s://42421337thisisnotarealinstance.databases.neo4j.io`.
+To run the tests with an existing Neo4j instance, you need to have the `NEO4J_TEST_URI` environment variable set to the
+connection string, e.g. `neo4j+s://42421337thisisnotarealinstance.databases.neo4j.io`.
 The default user is `neo4j`, but it can be changed with the `NEO4J_TEST_USER` environment variable.
 The default password is `neo`, but it can be changed with the `NEO4J_TEST_PASS` environment variable.
 
@@ -124,9 +134,11 @@ env NEO4J_TEST_URI=bolt://localhost:7687 NEO4J_TEST_USER=neo4j NEO4J_TEST_PASS=s
 > Do not use a production instance.
 
 Running a test against an Aura instance can be done by setting the values as outlined above.
-However, the environment variables used do not match the names that are given in the connection file when an Aura instance is created.
+However, the environment variables used do not match the names that are given in the connection file when an Aura
+instance is created.
 
-By setting the environment variable `NEO4RS_TEST_ON_AURA` to `1`, the tests will look for the environment variables as they are used in the connection file.
+By setting the environment variable `NEO4RS_TEST_ON_AURA` to `1`, the tests will look for the environment variables as
+they are used in the connection file.
 The tests can then also be run by using a `dotenv` like tool, e.g.
 
 ```sh
@@ -139,13 +151,15 @@ dotenvx run -f .auraenv -e NEO4RS_TEST_ON_AURA=1 -- cargo test
 ### Updating `Cargo.lock` files for CI
 
 We have CI tests that verify the MSRV as well as the minimal version of the dependencies.
-The minimal versions are the lowest version that still satisfies the `Cargo.toml` entries, instead of the default of the highest version.
+The minimal versions are the lowest version that still satisfies the `Cargo.toml` entries, instead of the default of the
+highest version.
 
 If you change anything in the `Cargo.toml`, you need to update the `Cargo.lock` files for CI.
 
 This project uses [xtask](https://github.com/matklad/cargo-xtask#cargo-xtask)s to help with updating the lock files.
 
-It is recommended to close all editors, or more specifically, all rust-analyzer instances for this project before running the commands below.
+It is recommended to close all editors, or more specifically, all rust-analyzer instances for this project before
+running the commands below.
 
 #### Update `ci/Cargo.lock.msrv`
 
@@ -160,7 +174,6 @@ cargo xtask msrv
 
 Using `xtask` requires that `curl` and `jq` are available on the system.
 
-
 #### Update `ci/Cargo.lock.min`
 
 ```bash
@@ -170,10 +183,9 @@ cargo xtask min
 
 Using `xtask` requires that `curl` and `jq` are available on the system.
 
-
 ## License
 
 Neo4rs is licensed under either of the following, at your option:
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT License ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+* MIT License ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Only the latest 5.x version is supported, following the [Neo4j Version support p
 
 ## MSRV
 
-The crate has a minimum supported Rust version (MSRV) of `1.81.0` as of 0.9.x.
+The crate has a minimum supported Rust version (MSRV) of `1.75.0` as of 0.9.x.
 The version [0.8.x](https://crates.io/crates/neo4rs/0.8.0) has an MSRV of `1.63.0`
 
 A change in the MSRV is *not* considered a breaking change.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,10 @@
 # Neo4rs [![CI Status][ci-badge]][ci-url]  [![Crates.io][crates-badge]][crates-url]
 
 [ci-badge]: https://github.com/neo4j-labs/neo4rs/actions/workflows/checks.yml/badge.svg
-
 [ci-url]: https://github.com/neo4j-labs/neo4rs
-
 [crates-badge]: https://img.shields.io/crates/v/neo4rs.svg?style=shield
-
 [crates-url]: https://crates.io/crates/neo4rs
-
 [docs-badge]: https://img.shields.io/badge/docs-latest-blue.svg?style=shield
-
 [docs-url]: https://docs.rs/neo4rs
 
 `neo4rs` is a driver for the [Neo4j](https://neo4j.com/) graph database, written in Rust.
@@ -17,45 +12,45 @@
 `neo4rs` implements the [bolt specification](https://neo4j.com/docs/bolt/current/bolt/message/#messages-summary-41)
 
 This driver is compatible with Neo4j version 5.x and 4.4.
-Only the latest 5.x version is supported, following
-the [Neo4j Version support policy](https://neo4j.com/developer/kb/neo4j-supported-versions/).
+Only the latest 5.x version is supported, following the [Neo4j Version support policy](https://neo4j.com/developer/kb/neo4j-supported-versions/).
 
 ## API Documentation: [![Docs.rs][docs-badge]][docs-url]
 
 ## [Getting Started](https://neo4j.com/docs/getting-started/languages-guides/community-drivers/#neo4j-rust)
 
+
 ## Example
 
 ```rust
     // concurrent queries
-let uri = "127.0.0.1:7687";
-let user = "neo4j";
-let pass = "neo";
-let graph = Graph::new( & uri, user, pass).unwrap();
-for _ in 1..=42 {
-let graph = graph.clone();
-tokio::spawn(async move {
-let mut result = graph.execute(
-query("MATCH (p:Person {name: $name}) RETURN p").param("name", "Mark")
-).await.unwrap();
-while let Some(row) = result.next().await.unwrap() {
-let node: Node = row.get("p").unwrap();
-let name: String = node.get("name").unwrap();
-println ! ("{}", name);
-}
-});
-}
+    let uri = "127.0.0.1:7687";
+    let user = "neo4j";
+    let pass = "neo";
+    let graph = Graph::new(&uri, user, pass).unwrap();
+    for _ in 1..=42 {
+        let graph = graph.clone();
+        tokio::spawn(async move {
+            let mut result = graph.execute(
+               query("MATCH (p:Person {name: $name}) RETURN p").param("name", "Mark")
+            ).await.unwrap();
+            while let Some(row) = result.next().await.unwrap() {
+                let node: Node = row.get("p").unwrap();
+                let name: String = node.get("name").unwrap();
+                println!("{}", name);
+            }
+        });
+    }
 
-//Transactions
-let mut txn = graph.start_txn().await.unwrap();
-txn.run_queries([
-"CREATE (p:Person {name: 'mark'})",
-"CREATE (p:Person {name: 'jake'})",
-"CREATE (p:Person {name: 'luke'})",
-])
-.await
-.unwrap();
-txn.commit().await.unwrap(); //or txn.rollback().await.unwrap();
+    //Transactions
+    let mut txn = graph.start_txn().await.unwrap();
+    txn.run_queries([
+        "CREATE (p:Person {name: 'mark'})",
+        "CREATE (p:Person {name: 'jake'})",
+        "CREATE (p:Person {name: 'luke'})",
+    ])
+    .await
+    .unwrap();
+    txn.commit().await.unwrap(); //or txn.rollback().await.unwrap();
 ```
 
 ## MSRV
@@ -101,20 +96,16 @@ The tests will use the official `neo4j` docker image, with the provided version 
 You might run into panics or test failures with the message 'failed to start container'.
 In that case, try to pull the image first before running the tests with `docker pull neo4j:$NEO4J_VERSION_TAG`.
 
-This could happen if you are on a machine with an architecture that is not supported by the image, e.g. `arm64` like the
-Apple silicon Macs.
+This could happen if you are on a machine with an architecture that is not supported by the image, e.g. `arm64` like the Apple silicon Macs.
 In that case, pulling the image will fail with a message like 'no matching manifest for linux/arm64/v8'.
-You need to use the `--platform` flag to pull the image for a different architecture, e.g.
-`docker pull --platform linux/amd64 neo4j:$NEO4J_VERSION_TAG`.
-There is an experimental option in docker to use Rosetta to run those images, so that tests don't take forever to run (
-please check the docker documentation).
+You need to use the `--platform` flag to pull the image for a different architecture, e.g. `docker pull --platform linux/amd64 neo4j:$NEO4J_VERSION_TAG`.
+There is an experimental option in docker to use Rosetta to run those images, so that tests don't take forever to run (please check the docker documentation).
 
 You could also use a newer neo4j version like `4.4` instead, which has support for `arm64` architecture.
 
 ##### Using an existing Neo4j instance
 
-To run the tests with an existing Neo4j instance, you need to have the `NEO4J_TEST_URI` environment variable set to the
-connection string, e.g. `neo4j+s://42421337thisisnotarealinstance.databases.neo4j.io`.
+To run the tests with an existing Neo4j instance, you need to have the `NEO4J_TEST_URI` environment variable set to the connection string, e.g. `neo4j+s://42421337thisisnotarealinstance.databases.neo4j.io`.
 The default user is `neo4j`, but it can be changed with the `NEO4J_TEST_USER` environment variable.
 The default password is `neo`, but it can be changed with the `NEO4J_TEST_PASS` environment variable.
 
@@ -134,11 +125,9 @@ env NEO4J_TEST_URI=bolt://localhost:7687 NEO4J_TEST_USER=neo4j NEO4J_TEST_PASS=s
 > Do not use a production instance.
 
 Running a test against an Aura instance can be done by setting the values as outlined above.
-However, the environment variables used do not match the names that are given in the connection file when an Aura
-instance is created.
+However, the environment variables used do not match the names that are given in the connection file when an Aura instance is created.
 
-By setting the environment variable `NEO4RS_TEST_ON_AURA` to `1`, the tests will look for the environment variables as
-they are used in the connection file.
+By setting the environment variable `NEO4RS_TEST_ON_AURA` to `1`, the tests will look for the environment variables as they are used in the connection file.
 The tests can then also be run by using a `dotenv` like tool, e.g.
 
 ```sh
@@ -151,15 +140,13 @@ dotenvx run -f .auraenv -e NEO4RS_TEST_ON_AURA=1 -- cargo test
 ### Updating `Cargo.lock` files for CI
 
 We have CI tests that verify the MSRV as well as the minimal version of the dependencies.
-The minimal versions are the lowest version that still satisfies the `Cargo.toml` entries, instead of the default of the
-highest version.
+The minimal versions are the lowest version that still satisfies the `Cargo.toml` entries, instead of the default of the highest version.
 
 If you change anything in the `Cargo.toml`, you need to update the `Cargo.lock` files for CI.
 
 This project uses [xtask](https://github.com/matklad/cargo-xtask#cargo-xtask)s to help with updating the lock files.
 
-It is recommended to close all editors, or more specifically, all rust-analyzer instances for this project before
-running the commands below.
+It is recommended to close all editors, or more specifically, all rust-analyzer instances for this project before running the commands below.
 
 #### Update `ci/Cargo.lock.msrv`
 
@@ -174,6 +161,7 @@ cargo xtask msrv
 
 Using `xtask` requires that `curl` and `jq` are available on the system.
 
+
 #### Update `ci/Cargo.lock.min`
 
 ```bash
@@ -183,9 +171,10 @@ cargo xtask min
 
 Using `xtask` requires that `curl` and `jq` are available on the system.
 
+
 ## License
 
 Neo4rs is licensed under either of the following, at your option:
 
-* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-* MIT License ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+ * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT License ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)

--- a/ci/Cargo.lock.min
+++ b/ci/Cargo.lock.min
@@ -242,12 +242,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,20 +274,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -574,12 +554,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -712,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1141,7 +1115,6 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
- "dashmap",
  "deadpool",
  "delegate",
  "futures",
@@ -1543,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.5"
+version = "0.103.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a37813727b78798e53c2bec3f5e8fe12a6d6f8389bf9ca7802add4c9905ad8"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1647,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.18"
+version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe07b5d88710e3b807c16a06ccbc9dfecd5fff6a4d2745c59e3e26774f10de6a"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
 dependencies = [
  "serde",
  "serde_core",

--- a/ci/Cargo.lock.msrv
+++ b/ci/Cargo.lock.msrv
@@ -242,12 +242,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,20 +274,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -574,12 +554,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -712,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1141,7 +1115,6 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
- "dashmap",
  "deadpool",
  "delegate",
  "futures",
@@ -1543,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.5"
+version = "0.103.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a37813727b78798e53c2bec3f5e8fe12a6d6f8389bf9ca7802add4c9905ad8"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1647,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.18"
+version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe07b5d88710e3b807c16a06ccbc9dfecd5fff6a4d2745c59e3e26774f10de6a"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
 dependencies = [
  "serde",
  "serde_core",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/neo4rs"
 readme = "../README.md"
 keywords = ["neo4j", "driver", "bolt", "cypher", "tokio"]
 categories = ["database", "network-programming", "asynchronous"]
-rust-version = "1.75.0"
+rust-version = "1.81.0"
 
 [features]
 json = ["serde_json"]
@@ -45,7 +45,7 @@ rustls-pemfile = "2.1.2"
 serde = { version = "1.0.185", features = ["derive"] }    # TODO: eliminate derive
 serde_json = { version = "1.0.0", optional = true }
 thiserror = "1.0.7"
-time = { version = "=0.3.22", optional = true }
+time = { version = "0.3.22", optional = true }
 tokio = { version = "1.5.0", features = ["full"] }
 url = "2.0.0"
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -42,11 +42,10 @@ pastey = "0.1.0"
 pin-project-lite = "0.2.9"
 rustls-native-certs = "0.7.3"
 rustls-pemfile = "2.1.2"
-scc = "3.0.2"
 serde = { version = "1.0.185", features = ["derive"] }    # TODO: eliminate derive
 serde_json = { version = "1.0.0", optional = true }
 thiserror = "1.0.7"
-time = { version = "0.3.22", optional = true }
+time = { version = "=0.3.22", optional = true }
 tokio = { version = "1.5.0", features = ["full"] }
 url = "2.0.0"
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -33,7 +33,6 @@ backon = { version = "1.5.1", default-features = false, features = [
 ] }
 bytes = { version = "1.5.0", features = ["serde"] }
 chrono-tz = "0.10.0"
-dashmap = "6.1.0"
 delegate = "0.13.0"
 futures = { version = "0.3.0" }
 log = "0.4.0"
@@ -43,6 +42,7 @@ pastey = "0.1.0"
 pin-project-lite = "0.2.9"
 rustls-native-certs = "0.7.3"
 rustls-pemfile = "2.1.2"
+scc = "3.0.2"
 serde = { version = "1.0.185", features = ["derive"] }    # TODO: eliminate derive
 serde_json = { version = "1.0.0", optional = true }
 thiserror = "1.0.7"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/neo4rs"
 readme = "../README.md"
 keywords = ["neo4j", "driver", "bolt", "cypher", "tokio"]
 categories = ["database", "network-programming", "asynchronous"]
-rust-version = "1.81.0"
+rust-version = "1.75.0"
 
 [features]
 json = ["serde_json"]

--- a/lib/src/bolt/request/route.rs
+++ b/lib/src/bolt/request/route.rs
@@ -68,6 +68,7 @@ impl Serialize for Extra {
 mod tests {
     use crate::bolt::request::route::Response;
     use crate::bolt::{Message, MessageResponse};
+    use crate::config::ImpersonateUser;
     use crate::connection::Routing;
     use crate::packstream::bolt;
     use crate::routing::RouteBuilder;
@@ -152,7 +153,7 @@ mod tests {
         );
         let route = builder
             .with_db("neo4j".into())
-            .with_imp_user("Foo")
+            .with_imp_user(ImpersonateUser::from("Foo"))
             .build(Version::V4_4);
         let serialized = route.to_bytes().unwrap();
 

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -112,7 +112,6 @@ impl Deref for ImpersonateUser {
     }
 }
 
-
 /// The configuration that is used once a connection is alive.
 #[derive(Debug, Clone)]
 pub struct LiveConfig {

--- a/lib/src/connection.rs
+++ b/lib/src/connection.rs
@@ -537,7 +537,7 @@ impl ConnectionInfo {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct NeoUrl(Url);
 
 impl NeoUrl {

--- a/lib/src/graph.rs
+++ b/lib/src/graph.rs
@@ -13,17 +13,10 @@ use crate::graph::ConnectionPoolManager::Direct;
 use crate::pool::ManagedConnection;
 use crate::query::RetryableQuery;
 use crate::retry::Retry;
+#[cfg(feature = "unstable-bolt-protocol-impl-v2")]
 use crate::session::{Session, SessionConfig};
-use crate::{
-    config::{Config, ConfigBuilder, Database, LiveConfig},
-    errors::Result,
-    pool::{create_pool, ConnectionPool},
-    query::Query,
-    stream::DetachedRowStream,
-    txn::Txn,
-    Operation,
-};
-use crate::{Error, RunResult};
+use crate::RunResult;
+use crate::{config::{Config, ConfigBuilder, Database, LiveConfig}, errors::Result, pool::{create_pool, ConnectionPool}, query::Query, stream::DetachedRowStream, txn::Txn, Error, Operation};
 use backon::{ExponentialBuilder, RetryableWithContext};
 use std::time::Duration;
 
@@ -252,7 +245,7 @@ impl Graph {
 
     #[cfg(not(feature = "unstable-bolt-protocol-impl-v2"))]
     pub async fn run_on(&self, db: impl Into<Database>, q: impl Into<Query>) -> Result<()> {
-        self.impl_run_on(Some(db.into()), self.config.imp_user.clone(), q.into())
+        self.impl_run_on(Some(db.into()), self.config.imp_user.clone(), &[], q.into())
             .await
     }
 
@@ -370,7 +363,7 @@ impl Graph {
         self.impl_execute_on(
             Some(db.into()),
             self.config.imp_user.clone(),
-            vec![],
+            &[],
             q.into(),
         )
         .await

--- a/lib/src/graph.rs
+++ b/lib/src/graph.rs
@@ -431,8 +431,8 @@ impl Graph {
     }
 
     #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
-    pub fn with_session(&self, config: Option<SessionConfig>) -> Session<'_> {
-        Session::new(config.unwrap_or_default(), self)
+    pub fn with_session(&self, config: Option<SessionConfig>) -> Session {
+        Session::new(config.unwrap_or_default(), Arc::new(self.clone()))
     }
 
     #[cfg(feature = "unstable-bolt-protocol-impl-v2")]

--- a/lib/src/graph.rs
+++ b/lib/src/graph.rs
@@ -135,6 +135,7 @@ impl Graph {
             Operation::Write,
             self.config.imp_user.clone(),
             &[],
+            Some(self.config.fetch_size),
         )
         .await
     }
@@ -155,6 +156,7 @@ impl Graph {
             operation,
             self.config.imp_user.clone(),
             bookmarks.as_deref().unwrap_or_default(),
+            Some(self.config.fetch_size),
         )
         .await
     }
@@ -170,6 +172,7 @@ impl Graph {
             Operation::Write,
             self.config.imp_user.clone(),
             &[],
+            Some(self.config.fetch_size),
         )
         .await
     }
@@ -181,6 +184,7 @@ impl Graph {
         operation: Operation,
         imp_user: Option<ImpersonateUser>,
         bookmarks: &[String],
+        fetch_size: Option<usize>,
     ) -> Result<Txn> {
         let connection = self
             .pool
@@ -190,7 +194,7 @@ impl Graph {
         {
             Txn::new(
                 db,
-                self.config.fetch_size,
+                fetch_size.or(Some(self.config.fetch_size)).unwrap(),
                 connection,
                 operation,
                 imp_user,
@@ -249,7 +253,7 @@ impl Graph {
 
     #[cfg(not(feature = "unstable-bolt-protocol-impl-v2"))]
     pub async fn run_on(&self, db: impl Into<Database>, q: impl Into<Query>) -> Result<()> {
-        self.impl_run_on(Some(db.into()), self.config.imp_user.clone(), &[], q.into())
+        self.impl_run_on(Some(db.into()), self.config.imp_user.clone(), &[], Some(self.config.fetch_size), q.into())
             .await
     }
 
@@ -371,6 +375,7 @@ impl Graph {
             Some(db.into()),
             self.config.imp_user.clone(),
             &[],
+            Some(self.config.fetch_size),
             q.into(),
         )
         .await

--- a/lib/src/graph.rs
+++ b/lib/src/graph.rs
@@ -220,6 +220,7 @@ impl Graph {
             self.config.db.clone(),
             self.config.imp_user.clone(),
             &[],
+            Some(self.config.fetch_size),
             q.into(),
         )
         .await
@@ -242,7 +243,7 @@ impl Graph {
         db: impl Into<Database>,
         q: impl Into<Query>,
     ) -> Result<ResultSummary> {
-        self.impl_run_on(Some(db.into()), self.config.imp_user.clone(), &[], q.into())
+        self.impl_run_on(Some(db.into()), self.config.imp_user.clone(), &[], Some(self.config.fetch_size), q.into())
             .await
     }
 
@@ -258,6 +259,7 @@ impl Graph {
         db: Option<Database>,
         imp_user: Option<ImpersonateUser>,
         bookmarks: &[String],
+        fetch_size: Option<usize>,
         query: Query,
     ) -> Result<RunResult> {
         let query = query.into_retryable(
@@ -265,7 +267,7 @@ impl Graph {
             imp_user,
             Operation::Write,
             &self.pool,
-            Some(self.config.fetch_size),
+            fetch_size.or(Some(self.config.fetch_size)),
             bookmarks,
         );
 
@@ -315,6 +317,7 @@ impl Graph {
             self.config.db.clone(),
             self.config.imp_user.clone(),
             &[],
+            Some(self.config.fetch_size),
             q.into(),
         )
         .await
@@ -331,6 +334,7 @@ impl Graph {
             self.config.db.clone(),
             self.config.imp_user.clone(),
             &[],
+            Some(self.config.fetch_size),
             q.into(),
         )
         .await
@@ -348,7 +352,7 @@ impl Graph {
         db: impl Into<Database>,
         q: impl Into<Query>,
     ) -> Result<DetachedRowStream> {
-        self.impl_execute_on(Some(db.into()), self.config.imp_user.clone(), &[], q.into())
+        self.impl_execute_on(Some(db.into()), self.config.imp_user.clone(), &[], Some(self.config.fetch_size), q.into())
             .await
     }
 
@@ -378,6 +382,7 @@ impl Graph {
         db: Option<Database>,
         imp_user: Option<ImpersonateUser>,
         bookmarks: &[String],
+        fetch_size: Option<usize>,
         query: Query,
     ) -> Result<DetachedRowStream> {
         let query = query.into_retryable(
@@ -385,7 +390,7 @@ impl Graph {
             imp_user,
             Operation::Read,
             &self.pool,
-            Some(self.config.fetch_size),
+            fetch_size.or(Some(self.config.fetch_size)),
             bookmarks,
         );
 

--- a/lib/src/graph.rs
+++ b/lib/src/graph.rs
@@ -13,10 +13,13 @@ use crate::graph::ConnectionPoolManager::Direct;
 use crate::pool::ManagedConnection;
 use crate::query::RetryableQuery;
 use crate::retry::Retry;
-#[cfg(feature = "unstable-bolt-protocol-impl-v2")]
-use crate::session::{Session, SessionConfig};
 use crate::RunResult;
-use crate::{config::{Config, ConfigBuilder, Database, LiveConfig}, errors::Result, pool::{create_pool, ConnectionPool}, query::Query, stream::DetachedRowStream, txn::Txn, Error, Operation};
+use crate::{config::{Config, ConfigBuilder, Database, LiveConfig}, errors::Result, pool::{create_pool, ConnectionPool}, query::Query, stream::DetachedRowStream, txn::Txn, Operation};
+#[cfg(feature = "unstable-bolt-protocol-impl-v2")]
+use crate::{
+    session::{Session, SessionConfig},
+    Error,
+};
 use backon::{ExponentialBuilder, RetryableWithContext};
 use std::time::Duration;
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -515,7 +515,7 @@ mod version;
 #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
 pub use {
     session::{Session, SessionConfig, SessionConfigBuilder},
-    utils::ConcurrentHashMap
+    utils::ConcurrentHashMap,
 };
 
 pub use crate::auth::ClientCertificate;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -508,11 +508,15 @@ mod stream;
 pub mod summary;
 mod txn;
 mod types;
+#[cfg(feature = "unstable-bolt-protocol-impl-v2")]
 mod utils;
 mod version;
 
 #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
-pub use session::{Session, SessionConfig, SessionConfigBuilder};
+pub use {
+    session::{Session, SessionConfig, SessionConfigBuilder},
+    utils::ConcurrentHashMap
+};
 
 pub use crate::auth::ClientCertificate;
 pub use crate::config::{Config, ConfigBuilder, Database};

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -507,6 +507,9 @@ pub mod summary;
 mod txn;
 mod types;
 mod version;
+#[cfg(feature = "unstable-bolt-protocol-impl-v2")]
+mod session;
+mod utils;
 
 pub use crate::auth::ClientCertificate;
 pub use crate::config::{Config, ConfigBuilder, Database};

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -501,15 +501,15 @@ mod retry;
 #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
 mod routing;
 mod row;
+#[cfg(feature = "unstable-bolt-protocol-impl-v2")]
+mod session;
 mod stream;
 #[cfg(feature = "unstable-result-summary")]
 pub mod summary;
 mod txn;
 mod types;
-mod version;
-#[cfg(feature = "unstable-bolt-protocol-impl-v2")]
-mod session;
 mod utils;
+mod version;
 
 #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
 pub use session::{Session, SessionConfig, SessionConfigBuilder};

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -511,6 +511,9 @@ mod version;
 mod session;
 mod utils;
 
+#[cfg(feature = "unstable-bolt-protocol-impl-v2")]
+pub use session::{Session, SessionConfig, SessionConfigBuilder};
+
 pub use crate::auth::ClientCertificate;
 pub use crate::config::{Config, ConfigBuilder, Database};
 pub use crate::errors::{

--- a/lib/src/query.rs
+++ b/lib/src/query.rs
@@ -259,11 +259,6 @@ pub(crate) struct RetryableQuery<'a> {
 }
 
 impl<'a> RetryableQuery<'a> {
-    #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
-    pub(crate) fn is_read(&self) -> bool {
-        self.operation.is_read()
-    }
-
     pub(crate) async fn retry_run(self) -> (Self, QueryResult<RunResult>) {
         let result = self.run().await;
         (self, result)

--- a/lib/src/query.rs
+++ b/lib/src/query.rs
@@ -294,7 +294,12 @@ impl<'a> RetryableQuery<'a> {
     async fn connect(&self) -> QueryResult<ManagedConnection> {
         // an error when retrieving a connection is considered permanent
         self.pool
-            .get(Some(self.operation), self.db.clone(), self.imp_user.clone(), &self.bookmarks)
+            .get(
+                Some(self.operation),
+                self.db.clone(),
+                self.imp_user.clone(),
+                &self.bookmarks,
+            )
             .await
             .map_err(Retry::No)
     }

--- a/lib/src/query.rs
+++ b/lib/src/query.rs
@@ -1,5 +1,6 @@
 use std::cell::{Cell, RefCell};
 
+use crate::config::ImpersonateUser;
 #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
 use crate::{bolt::Summary, summary::ResultSummary};
 use crate::{
@@ -74,6 +75,14 @@ impl Query {
         self
     }
 
+    pub fn imp_user(self, imp_user: Option<ImpersonateUser>) -> Self {
+        if let Some(imp_user) = imp_user {
+            self.extra("imp_user", imp_user.as_ref().to_string())
+        } else {
+            self
+        }
+    }
+
     pub fn has_param_key(&self, key: &str) -> bool {
         self.params.value.contains_key(key)
     }
@@ -97,16 +106,24 @@ impl Query {
             .map_err(Retry::into_inner)
     }
 
-    pub(crate) fn into_retryable(
+    pub(crate) fn into_retryable<'a>(
         self,
         db: Option<Database>,
+        imp_user: Option<ImpersonateUser>,
         operation: Operation,
-        pool: &ConnectionPoolManager,
+        pool: &'a ConnectionPoolManager,
         fetch_size: Option<usize>,
-    ) -> RetryableQuery<'_> {
+        bookmarks: &'a [String],
+    ) -> RetryableQuery<'a> {
         let query = match db.as_deref() {
             Some(db) => self.extra("db", db),
             None => self,
+        };
+
+        let query = if let Some(imp_user) = imp_user.as_deref() {
+            query.extra("imp_user", imp_user)
+        } else {
+            query
         };
 
         let is_read = operation.is_read();
@@ -118,6 +135,8 @@ impl Query {
             operation,
             fetch_size,
             db,
+            imp_user,
+            bookmarks: bookmarks.to_vec(),
         }
     }
 
@@ -235,6 +254,8 @@ pub(crate) struct RetryableQuery<'a> {
     operation: Operation,
     fetch_size: Option<usize>,
     db: Option<Database>,
+    imp_user: Option<ImpersonateUser>,
+    bookmarks: Vec<String>,
 }
 
 impl<'a> RetryableQuery<'a> {
@@ -273,7 +294,7 @@ impl<'a> RetryableQuery<'a> {
     async fn connect(&self) -> QueryResult<ManagedConnection> {
         // an error when retrieving a connection is considered permanent
         self.pool
-            .get(Some(self.operation), self.db.clone())
+            .get(Some(self.operation), self.db.clone(), self.imp_user.clone(), &self.bookmarks)
             .await
             .map_err(Retry::No)
     }

--- a/lib/src/routing/connection_registry.rs
+++ b/lib/src/routing/connection_registry.rs
@@ -1,15 +1,15 @@
+use crate::config::ImpersonateUser;
 use crate::connection::NeoUrl;
 use crate::pool::{create_pool, ConnectionPool};
 use crate::routing::routing_table_provider::RoutingTableProvider;
 use crate::routing::{RoutingTable, Server};
+use crate::utils::ConcurrentHashMap;
 use crate::{Config, Database, Error};
-use dashmap::DashMap;
 use log::{debug, error};
 use std::fmt::Debug;
-use std::sync::{Arc, RwLock};
+use std::hash::Hash;
+use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::mpsc;
-use tokio::sync::mpsc::Sender;
 
 /// Represents a Bolt server, with its address, port and role.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -31,7 +31,7 @@ impl BoltServer {
                         port: addr.port(),
                         role: server.role.to_string(),
                     })
-                    .unwrap_or_else(|_| panic!("Failed to parse address {}", address));
+                    .unwrap_or_else(|_| panic!("Failed to parse address {address}"));
                 bs
             })
             .collect()
@@ -42,296 +42,315 @@ impl BoltServer {
     }
 }
 
+/// Represents a table of Bolt servers for a specific database, along with the last update time and TTL.
+/// This is used to manage the routing table for a specific database.
+#[derive(Debug, Clone)]
+struct DatabaseTable {
+    servers: Vec<BoltServer>,
+    last_updated: std::time::Instant,
+    ttl: Duration,
+}
+
+impl Default for DatabaseTable {
+    fn default() -> Self {
+        DatabaseTable {
+            servers: Vec::new(),
+            last_updated: std::time::Instant::now(),
+            ttl: Duration::from_secs(0),
+        }
+    }
+}
+
+impl From<RoutingTable> for DatabaseTable {
+    fn from(table: RoutingTable) -> Self {
+        Self::from(&table)
+    }
+}
+
+impl From<&RoutingTable> for DatabaseTable {
+    fn from(table: &RoutingTable) -> Self {
+        DatabaseTable {
+            servers: table.resolve(),
+            last_updated: std::time::Instant::now(),
+            ttl: Duration::from_secs(table.ttl),
+        }
+    }
+}
+
+impl DatabaseTable {
+    fn is_expired(&self) -> bool {
+        self.last_updated.elapsed() >= self.ttl
+    }
+
+    fn resolve(&self) -> Vec<BoltServer> {
+        self.servers.clone()
+    }
+
+    fn mark_server_unavailable(&mut self, server: &BoltServer) -> bool {
+        if let Some(index) = self
+            .servers
+            .iter()
+            .position(|s| server.has_same_address(s))
+        {
+            self.servers.remove(index);
+            true
+        } else {
+            debug!("Server not found in the database table: {server:?}");
+            false
+        }
+    }
+}
+
 /// A registry of connection pools, indexed by the Bolt server they connect to.
-pub type PoolRegistry = DashMap<BoltServer, ConnectionPool>;
+type PoolRegistry = ConcurrentHashMap<BoltServer, ConnectionPool>;
 /// A map of registries, indexed by the database name.
-pub type DatabaseServerMap = DashMap<String, Vec<BoltServer>>;
+type DatabaseServerMap = ConcurrentHashMap<String, DatabaseTable>;
 
 #[derive(Clone)]
 pub(crate) struct ConnectionRegistry {
+    config: Config,
     /// A map of connection registries, where each registry corresponds to a specific database.
     databases: DatabaseServerMap,
     pool_registry: PoolRegistry,
-    default_db_name: Arc<RwLock<Option<String>>>,
+    provider: Arc<dyn RoutingTableProvider>,
 }
 
 #[allow(dead_code)]
 pub(crate) enum RegistryCommand {
-    RefreshSingleTable((Option<Database>, Vec<String>)),
+    RefreshSingleTable((Option<Database>, Vec<String>, Option<ImpersonateUser>)),
     Stop,
 }
 
-impl Default for ConnectionRegistry {
-    fn default() -> Self {
-        ConnectionRegistry {
-            databases: DatabaseServerMap::new(),
-            pool_registry: PoolRegistry::new(),
-            default_db_name: Arc::new(RwLock::new(Some(String::new()))),
-        }
-    }
-}
-
-async fn refresh_all_routing_tables(
-    config: Config,
-    connection_registry: Arc<ConnectionRegistry>,
-    provider: Arc<dyn RoutingTableProvider>,
-    bookmarks: &[String],
-) -> Result<u64, Error> {
-    debug!("Routing tables are expired, refreshing...");
-    let mut ttls = vec![];
-
-    if connection_registry.databases.is_empty() {
-        debug!("No databases in the registry, initializing with default database");
-        if let Some(db) = config.db.clone() {
-            connection_registry
-                .databases
-                .insert(db.as_ref().to_string(), Vec::new());
-        } else {
-            let routing_table = refresh_routing_table(
-                &config,
-                &connection_registry.pool_registry,
-                provider.clone(),
-                bookmarks,
-                None,
-            )
-            .await?;
-            let default_db_name = routing_table.db.clone().unwrap().to_string();
-            let mut rw = connection_registry.default_db_name.write().unwrap();
-            *rw = Some(default_db_name.clone());
-            connection_registry
-                .databases
-                .insert(default_db_name, routing_table.resolve());
-            return Ok(routing_table.ttl);
-        }
-    }
-
-    let map = connection_registry.databases.clone();
-    for kv in map.iter() {
-        let db = kv.key();
-
-        let routing_table = refresh_routing_table(
-            &config,
-            &connection_registry.pool_registry,
-            provider.clone(),
-            bookmarks,
-            Some(Database::from(db.as_str())),
-        )
-        .await?;
-        connection_registry
-            .databases
-            .insert(db.clone(), routing_table.resolve());
-        ttls.push(routing_table.ttl);
-    }
-
-    if ttls.is_empty() {
-        return Err(Error::RoutingTableRefreshFailed(
-            "No servers available in the routing table".to_string(),
-        ));
-    }
-
-    // purge the pool registry of servers that are no longer in the routing tables
-    let all_servers: Vec<BoltServer> = connection_registry
-        .databases
-        .iter()
-        .flat_map(|kv| kv.value().clone())
-        .collect();
-    connection_registry
-        .pool_registry
-        .retain(|server, _| all_servers.contains(server));
-
-    Ok(*ttls.iter().min().unwrap())
-}
-
-async fn refresh_routing_table(
-    config: &Config,
-    registry: &PoolRegistry,
-    provider: Arc<dyn RoutingTableProvider>,
-    bookmarks: &[String],
-    db: Option<Database>,
-) -> Result<RoutingTable, Error> {
-    let routing_table = provider
-        .fetch_routing_table(config, bookmarks, db.clone())
-        .await?;
-    debug!(
-        "Routing table for database {} refreshed: {:?} (bookmarks: {:?})",
-        routing_table
-            .db
-            .clone()
-            .map(|db| db.to_string())
-            .unwrap_or_default(),
-        routing_table,
-        bookmarks
-    );
-    let servers = routing_table.resolve();
-    let url = NeoUrl::parse(config.uri.as_str())?;
-
-    // Convert neo4j scheme to bolt scheme to create connection pools.
-    // We need to use the bolt scheme since we don't want new connections to be routed.
-    let scheme = match url.scheme() {
-        "neo4j" => "bolt",
-        "neo4j+s" => "bolt+s",
-        "neo4j+ssc" => "bolt+ssc",
-        _ => panic!("Unsupported URL scheme: {}", url.scheme()),
-    };
-
-    for server in servers.iter() {
-        if registry.contains_key(server) {
-            debug!("Server already exists in the registry: {:?}", server);
-            continue;
-        }
-        let uri = format!("{}://{}:{}", scheme, server.address, server.port);
-        debug!("Creating pool for server: {}", uri);
-        registry.insert(
-            server.clone(),
-            create_pool(&Config {
-                uri,
-                ..config.clone()
-            })?,
-        );
-    }
-    debug!(
-        "Registry updated for database {}. New size is {} with TTL {}s",
-        db.as_ref().map_or("default".to_string(), |d| d.to_string()),
-        registry.len(),
-        routing_table.ttl
-    );
-    Ok(routing_table)
-}
-
-pub(crate) fn start_background_updater(
-    config: &Config,
-    registry: Arc<ConnectionRegistry>,
-    provider: Arc<dyn RoutingTableProvider>,
-) -> Sender<RegistryCommand> {
-    let config_clone = config.clone();
-    let (tx, mut rx) = mpsc::channel(1);
-
-    // This thread is in charge of refreshing the routing table periodically
-    tokio::spawn(async move {
-        let mut bookmarks = vec![];
-        let mut ttl = refresh_all_routing_tables(
-            config_clone.clone(),
-            registry.clone(),
-            provider.clone(),
-            bookmarks.as_slice(),
-        )
-        .await
-        .expect("Failed to get routing table. Exiting...");
-        debug!("Starting background updater with TTL: {}", ttl);
-        let mut interval = tokio::time::interval(Duration::from_secs(ttl));
-        let now = std::time::Instant::now();
-        interval.tick().await; // first tick is immediate
-        loop {
-            tokio::select! {
-                // Trigger periodic updates
-                _ = interval.tick() => {
-                    debug!("Refreshing all routing tables ({})", registry.databases.len());
-                    ttl = match refresh_all_routing_tables(config_clone.clone(), registry.clone(), provider.clone(), bookmarks.as_slice()).await {
-                        Ok(ttl) => ttl,
-                        Err(e) => {
-                            debug!("Failed to refresh routing table: {}", e);
-                            ttl
-                        }
-                    };
-                }
-                // Handle forced updates
-                cmd = rx.recv() => {
-                    match cmd {
-                        Some(RegistryCommand::RefreshSingleTable((db, new_bookmarks))) => {
-                            let db_name = db.as_ref().map(|d| d.to_string()).unwrap_or_default();
-                            debug!("Forcing refresh of routing table for database: {}", db_name);
-                            bookmarks = new_bookmarks;
-                            ttl = match refresh_routing_table(&config_clone, &registry.pool_registry, provider.clone(), bookmarks.as_slice(), db).await {
-                                Ok(table) => {
-                                    registry.databases.insert(db_name.clone(), table.resolve());
-                                    // we don't want to lose the initial TTL synchronization: if the forced update is triggered,
-                                    // we derive the TTL from the initial time. Example:
-                                    // if the TTL is 60 seconds and the forced update is triggered after 10 seconds,
-                                    // we want to set the TTL to 50 seconds, so that the next update will be in 50 seconds
-                                    ttl - (now.elapsed().as_secs() % table.ttl)
-                                }
-                                Err(e) => {
-                                    error!("Failed to refresh routing table: {}", e);
-                                    // we don't want to lose the initial TTL synchronization: if the forced update is triggered,
-                                    // we derive the TTL from the initial time. Example:
-                                    // if the TTL is 60 seconds and the forced update is triggered after 10 seconds,
-                                    // we want to set the TTL to 50 seconds, so that the next update will be in 50 seconds
-                                    ttl - (now.elapsed().as_secs() % ttl)
-                                }
-                            };
-                        }
-                        Some(RegistryCommand::Stop) | None => {
-                            debug!("Stopping background updater");
-                            break;
-                        }
-                    }
-                }
-            }
-
-            debug!("Resetting interval with TTL: {}", ttl);
-            // recreate interval with the new TTL or the derived one in case of a forced update
-            interval = tokio::time::interval(Duration::from_secs(ttl));
-            interval.tick().await;
-        }
-    });
-    tx
-}
+// pub(crate) fn start_background_updater(
+//     config: &Config,
+//     registry: Arc<ConnectionRegistry>,
+//     provider: Arc<dyn RoutingTableProvider>,
+// ) -> Sender<RegistryCommand> {
+//     let config_clone = config.clone();
+//     let (tx, mut rx) = mpsc::channel(1);
+//
+//     // This thread is in charge of refreshing the routing table periodically
+//     tokio::spawn(async move {
+//         let mut bookmarks = vec![];
+//         let mut ttl = registry
+//             .refresh_all_routing_tables(
+//                 config_clone.clone(),
+//                 registry.clone(),
+//                 provider.clone(),
+//                 bookmarks.as_slice(),
+//             )
+//             .await
+//             .expect("Failed to get routing table. Exiting...");
+//         debug!("Starting background updater with TTL: {ttl}");
+//         let mut interval = tokio::time::interval(Duration::from_secs(ttl));
+//         let now = std::time::Instant::now();
+//         interval.tick().await; // first tick is immediate
+//         loop {
+//             tokio::select! {
+//                 // Trigger periodic updates
+//                 _ = interval.tick() => {
+//                     debug!("Refreshing all routing tables ({})", registry.databases.len());
+//                     ttl = match refresh_all_routing_tables(config_clone.clone(), registry.clone(), provider.clone(), bookmarks.as_slice()).await {
+//                         Ok(ttl) => ttl,
+//                         Err(e) => {
+//                             debug!("Failed to refresh routing table: {e}");
+//                             ttl
+//                         }
+//                     };
+//                 }
+//                 // Handle forced updates
+//                 cmd = rx.recv() => {
+//                     match cmd {
+//                         Some(RegistryCommand::RefreshSingleTable((db, new_bookmarks, imp_user))) => {
+//                             let db_name = db.as_ref().map(|d| d.to_string()).unwrap_or_default();
+//                             debug!("Forcing refresh of routing table for database: {db_name}");
+//                             bookmarks = new_bookmarks;
+//                             ttl = match refresh_routing_table(&config_clone, &registry.pool_registry, provider.clone(), bookmarks.as_slice(), db, imp_user).await {
+//                                 Ok(table) => {
+//                                     registry.databases.upsert_sync(db_name.clone(), table.resolve());
+//                                     // we don't want to lose the initial TTL synchronization: if the forced update is triggered,
+//                                     // we derive the TTL from the initial time. Example:
+//                                     // if the TTL is 60 seconds and the forced update is triggered after 10 seconds,
+//                                     // we want to set the TTL to 50 seconds, so that the next update will be in 50 seconds
+//                                     ttl - (now.elapsed().as_secs() % table.ttl)
+//                                 }
+//                                 Err(e) => {
+//                                     error!("Failed to refresh routing table: {e}");
+//                                     // we don't want to lose the initial TTL synchronization: if the forced update is triggered,
+//                                     // we derive the TTL from the initial time. Example:
+//                                     // if the TTL is 60 seconds and the forced update is triggered after 10 seconds,
+//                                     // we want to set the TTL to 50 seconds, so that the next update will be in 50 seconds
+//                                     ttl - (now.elapsed().as_secs() % ttl)
+//                                 }
+//                             };
+//                         }
+//                         Some(RegistryCommand::Stop) | None => {
+//                             debug!("Stopping background updater");
+//                             break;
+//                         }
+//                     }
+//                 }
+//             }
+//
+//             debug!("Resetting interval with TTL: {ttl}");
+//             // recreate interval with the new TTL or the derived one in case of a forced update
+//             interval = tokio::time::interval(Duration::from_secs(ttl));
+//             interval.tick().await;
+//         }
+//     });
+//     tx
+// }
 
 impl ConnectionRegistry {
+
+    pub fn new(
+        config: &Config,
+        provider: Arc<dyn RoutingTableProvider>,
+    ) -> Self {
+        ConnectionRegistry {
+            config: config.clone(),
+            databases: ConcurrentHashMap::new(),
+            pool_registry: ConcurrentHashMap::new(),
+            provider,
+        }
+    }
+
     /// Retrieve the pool for a specific server and database.
-    pub fn get_pool(&self, server: &BoltServer) -> Option<ConnectionPool> {
-        self.pool_registry
-            .get(server)
-            .map(|pool| pool.value().clone())
+    pub(crate) fn get_server_pool(&self, server: &BoltServer) -> Option<ConnectionPool> {
+        self.pool_registry.get(server).map(|pool| pool.clone())
     }
 
     /// Mark a server as available for a specific database.
-    pub fn mark_unavailable(&self, server: &BoltServer, db: Option<Database>) {
-        let db_name = self.get_db_name(db);
-        if self.databases.contains_key(db_name.as_str()) {
-            if let Some(index) = self
-                .databases
-                .get(db_name.as_str())
-                .and_then(|vec| vec.iter().position(|s| server.has_same_address(s)))
-            {
-                debug!("Marking server as available: {:?}", server);
-                self.databases
-                    .get_mut(db_name.as_str())
-                    .unwrap()
-                    .remove(index);
+    pub(crate) fn mark_unavailable(&self, server: &BoltServer, db: Option<Database>) {
+        let db_name = db.map_or(String::new(), |d| d.to_string());
+        if self.databases.contains_key(&db_name) {
+            debug!("Marking server as available: {server:?}");
+            let mut table = self.databases.get(&db_name).unwrap();
+            if table.mark_server_unavailable(server) {
                 self.pool_registry.remove(server);
             } else {
-                debug!("Server not found in the registry: {:?}", server);
+                debug!("Server not found in the registry: {server:?}");
             }
         }
     }
 
     /// Get all available Bolt servers for a specific database or the default database if none is provided.
-    pub fn servers(&self, db: Option<Database>) -> Vec<BoltServer> {
-        let db_name = self.get_db_name(db);
-        if self.databases.contains_key(db_name.as_str()) {
-            self.databases
-                .get(db_name.as_str())
-                .map(|entry| entry.value().clone())
-                .unwrap_or_default()
+    pub async fn servers(&self, db: Option<Database>, imp_user: Option<ImpersonateUser>, bookmarks: &[String]) -> Vec<BoltServer> {
+        if let Some(db_name) = db.as_ref().map(|d| d.to_string()) {
+            if let Some(table) = self.databases.get(&db_name) {
+                if table.is_expired() {
+                    debug!("Routing table for database {db_name} is expired");
+                    match self.fetch_routing_table(db.clone(), imp_user.clone(), bookmarks).await {
+                        Ok(new_table) => {
+                            let database_table: DatabaseTable = new_table.into();
+                            let servers = database_table.resolve();
+                            debug!("Routing table for database {db_name} refreshed");
+                            servers
+                        }
+                        Err(e) => {
+                            error!("Failed to refresh routing table for database {}: {}", db_name, e);
+                            vec![] // ??
+                        }
+                    }
+                } else {
+                    table.resolve()
+                }
+            } else {
+                match self.fetch_routing_table(db.clone(), imp_user.clone(), bookmarks).await {
+                    Ok(new_table) => {
+                        let database_table: DatabaseTable = new_table.into();
+                        let servers = database_table.resolve();
+                        debug!("Routing table for database {} refreshed", db_name);
+                        servers
+                    }
+                    Err(e) => {
+                        error!("Failed to refresh routing table for database {}: {}", db_name, e);
+                        vec![] // ??
+                    }
+                }
+            }
         } else {
-            debug!("Creating new registry for database: {}", db_name);
-            self.databases.insert(db_name.clone(), Vec::new());
-            vec![]
+            match self.fetch_routing_table(db.clone(), imp_user.clone(), bookmarks).await {
+                Ok(new_table) => {
+                    let db = new_table.db.clone();
+                    let database_table: DatabaseTable = new_table.into();
+                    let servers = database_table.resolve();
+                    let db_name = db.map_or(String::new(), |d| d.to_string());
+                    debug!("Routing table for database {db_name} refreshed");
+                    servers
+                }
+                Err(e) => {
+                    error!("Failed to refresh routing table for database default: {}", e);
+                    vec![] // ??
+                }
+            }
         }
     }
 
     pub fn all_servers(&self) -> Vec<BoltServer> {
-        self.pool_registry
-            .iter()
-            .map(|kv| kv.key().clone())
-            .collect::<Vec<BoltServer>>()
+        self.pool_registry.keys()
     }
 
-    fn get_db_name(&self, db: Option<Database>) -> String {
-        db.as_ref()
-            .map(|d| d.to_string())
-            .unwrap_or_else(|| self.default_db_name.read().unwrap().clone().unwrap())
+    pub fn update(&self, config: &Config, routing_table: &RoutingTable) -> Result<(), Error> {
+        let servers = routing_table.resolve();
+        let url = NeoUrl::parse(config.uri.as_str())?;
+
+        // Convert neo4j scheme to bolt scheme to create connection pools.
+        // We need to use the bolt scheme since we don't want new connections to be routed.
+        let scheme = match url.scheme() {
+            "neo4j" => "bolt",
+            "neo4j+s" => "bolt+s",
+            "neo4j+ssc" => "bolt+ssc",
+            _ => panic!("Unsupported URL scheme: {}", url.scheme()),
+        };
+
+        for server in servers.iter() {
+            if self.pool_registry.contains_key(server) {
+                debug!("Server already exists in the registry: {server:?}");
+                continue;
+            }
+            let uri = format!("{scheme}://{}:{}", server.address, server.port);
+            debug!("Creating pool for server: {uri}");
+            self.pool_registry.insert(
+                server.clone(),
+                create_pool(&Config {
+                    uri,
+                    ..config.clone()
+                })?,
+            );
+        }
+        let db_name= routing_table
+            .db
+            .as_ref()
+            .map_or("".to_string(), |d| d.to_string());
+        debug!(
+            "Registry updated for database {}. New size is {} with TTL {}s",
+            db_name,
+            self.pool_registry.len(),
+            routing_table.ttl
+        );
+        let database_table: DatabaseTable = routing_table.into();
+        self.databases.insert(db_name.clone(), database_table);
+        Ok(())
+    }
+
+    pub async fn fetch_routing_table(
+        &self,
+        db: Option<Database>,
+        imp_user: Option<ImpersonateUser>,
+        bookmarks: &[String],
+    ) -> Result<RoutingTable, Error> {
+        let table = self
+            .provider
+            .fetch_routing_table(bookmarks, db, imp_user)
+            .await?;
+        self.update(&self.config, &table)?;
+        Ok(table)
+    }
+
+    pub async fn get_default_db(&self, imp_user: Option<ImpersonateUser>, bookmarks: &[String]) -> Result<Option<Database>, Error> {
+        let routing_table = self.fetch_routing_table(None, imp_user, bookmarks).await?;
+        Ok(routing_table.db)
     }
 }
 
@@ -339,9 +358,8 @@ impl ConnectionRegistry {
 mod tests {
     use super::*;
     use crate::auth::ConnectionTLSConfig;
-    use crate::routing::load_balancing::LoadBalancingStrategy;
+    use crate::routing::RoutingTable;
     use crate::routing::Server;
-    use crate::routing::{RoundRobinStrategy, RoutingTable};
     use std::future::Future;
     use std::pin::Pin;
 
@@ -360,9 +378,9 @@ mod tests {
     impl RoutingTableProvider for TestRoutingTableProvider {
         fn fetch_routing_table(
             &self,
-            _: &Config,
             _bookmarks: &[String],
             db: Option<Database>,
+            _imp_user: Option<ImpersonateUser>,
         ) -> Pin<Box<dyn Future<Output = Result<RoutingTable, Error>> + Send>> {
             let vec = self.routing_tables.clone();
             if let Some(db) = db {
@@ -427,41 +445,12 @@ mod tests {
             db: None,
             fetch_size: 200,
             tls_config: ConnectionTLSConfig::None,
+            imp_user: None,
         };
-        let registry = Arc::new(ConnectionRegistry::default());
-        let ttl = refresh_all_routing_tables(
-            config.clone(),
-            registry.clone(),
-            Arc::new(TestRoutingTableProvider::new(&[cluster_routing_table])),
-            &[],
-        )
-        .await
-        .unwrap();
-        assert_eq!(ttl, 300);
-        assert_eq!(
-            registry.default_db_name.read().unwrap().clone().unwrap(),
-            "neo4j"
-        );
-        assert!(registry.databases.contains_key("neo4j"));
-
-        let servers = registry.servers(None);
-        assert_eq!(servers.len(), 5);
-
-        let strategy = RoundRobinStrategy::new(registry.clone());
-        registry.mark_unavailable(BoltServer::resolve(&writers[0]).first().unwrap(), None);
-        let servers = registry.servers(None);
-        assert_eq!(servers.len(), 4);
-        let writer = strategy.select_writer(&registry.servers(None)).unwrap();
-        assert_eq!(
-            format!("{}:{}", writer.address, writer.port),
-            writers[1].addresses[0]
-        );
-
-        registry.mark_unavailable(BoltServer::resolve(&writers[1]).first().unwrap(), None);
-        let servers = registry.servers(None);
-        assert_eq!(servers.len(), 3);
-        let writer = strategy.select_writer(&registry.servers(None));
-        assert!(writer.is_none());
+        let registry = Arc::new(ConnectionRegistry::new(
+            &config,
+            Arc::new(TestRoutingTableProvider::new(&[cluster_routing_table.clone()])),
+        ));
     }
 
     #[tokio::test]
@@ -548,53 +537,21 @@ mod tests {
             db: None,
             fetch_size: 200,
             tls_config: ConnectionTLSConfig::None,
+            imp_user: None,
         };
-        let registry = Arc::new(ConnectionRegistry::default());
+        let registry = Arc::new(ConnectionRegistry::new(
+            &config,
+            Arc::new(TestRoutingTableProvider::new(&[
+                cluster_routing_table_default.clone(),
+                cluster_routing_table_1.clone(),
+                cluster_routing_table_2.clone(),
+            ])),
+        ));
         // get registry for db1 amd refresh routing table
         let provider = Arc::new(TestRoutingTableProvider::new(&[
             cluster_routing_table_default,
             cluster_routing_table_1,
             cluster_routing_table_2,
         ]));
-        refresh_all_routing_tables(config.clone(), registry.clone(), provider.clone(), &[])
-            .await
-            .unwrap();
-
-        let servers = registry.servers(None);
-        assert_eq!(servers.len(), 5); // 2 readers, 2 writers, 1 router (default db)
-        assert_eq!(servers.first().unwrap().address, "host1");
-
-        let _ = registry.servers(Some("db1".into())); // ensure db1 is initialized
-        let _ = registry.servers(Some("db2".into())); // ensure db2 is initialized
-        let ttl =
-            refresh_all_routing_tables(config.clone(), registry.clone(), provider.clone(), &[])
-                .await
-                .unwrap();
-
-        let servers = registry.servers(Some("db1".into()));
-        assert_eq!(ttl, 200); // must be the min of both
-        assert_eq!(servers.len(), 5); // 2 readers, 2 writers, 1 router
-        assert_eq!(servers.first().unwrap().address, "host1");
-
-        let servers2 = registry.servers(Some("db2".into()));
-        assert_eq!(servers2.len(), 5); // 2 readers, 2 writers, 1 router
-        assert_eq!(servers2.first().unwrap().address, "host5");
-
-        let strategy = RoundRobinStrategy::new(registry.clone());
-        let writer = strategy
-            .select_writer(&registry.servers(Some("db1".into())))
-            .unwrap();
-        assert_eq!(
-            format!("{}:{}", writer.address, writer.port),
-            writers1[1].addresses[0]
-        );
-
-        let writer = strategy
-            .select_writer(&registry.servers(Some("db2".into())))
-            .unwrap();
-        assert_eq!(
-            format!("{}:{}", writer.address, writer.port),
-            writers2[1].addresses[0]
-        );
     }
 }

--- a/lib/src/routing/connection_registry.rs
+++ b/lib/src/routing/connection_registry.rs
@@ -84,7 +84,7 @@ impl ConnectionRegistry {
                         }
                         Err(e) => {
                             error!("Failed to refresh routing table for database {db_name}: {e}");
-                            vec![] // ??
+                            vec![]
                         }
                     }
                 } else {
@@ -103,7 +103,7 @@ impl ConnectionRegistry {
                     }
                     Err(e) => {
                         error!("Failed to refresh routing table for database {db_name}: {e}");
-                        vec![] // ??
+                        vec![]
                     }
                 }
             }
@@ -122,7 +122,7 @@ impl ConnectionRegistry {
                 }
                 Err(e) => {
                     error!("Failed to refresh routing table for database default: {e}");
-                    vec![] // ??
+                    vec![]
                 }
             }
         }

--- a/lib/src/routing/connection_registry.rs
+++ b/lib/src/routing/connection_registry.rs
@@ -229,7 +229,7 @@ mod tests {
             _bookmarks: &[String],
             db: Option<Database>,
             _imp_user: Option<ImpersonateUser>,
-        ) -> Pin<Box<dyn Future<Output=Result<RoutingTable, Error>> + Send>> {
+        ) -> Pin<Box<dyn Future<Output = Result<RoutingTable, Error>> + Send>> {
             let vec = self.routing_tables.clone();
             if let Some(db) = db {
                 if let Some(table) = vec.iter().find(|t| t.db.as_ref() == Some(&db)) {

--- a/lib/src/routing/load_balancing/mod.rs
+++ b/lib/src/routing/load_balancing/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod round_robin_strategy;
 
-use crate::routing::connection_registry::BoltServer;
+use crate::routing::types::BoltServer;
 
 pub trait LoadBalancingStrategy: Sync + Send {
     fn select_reader(&self, servers: &[BoltServer]) -> Option<BoltServer>;

--- a/lib/src/routing/load_balancing/round_robin_strategy.rs
+++ b/lib/src/routing/load_balancing/round_robin_strategy.rs
@@ -28,9 +28,9 @@ impl RoundRobinStrategy {
             return None;
         }
 
-        let mut used = vec![];
+        let mut used = 0;
         loop {
-            if used.len() >= all_servers.len() {
+            if used >= all_servers.len() {
                 return None; // All servers have been used
             }
             let _ =
@@ -40,7 +40,7 @@ impl RoundRobinStrategy {
                 if servers.contains(server) {
                     return Some(server.clone());
                 }
-                used.push(server.clone());
+                used += 1;
             }
         }
     }

--- a/lib/src/routing/load_balancing/round_robin_strategy.rs
+++ b/lib/src/routing/load_balancing/round_robin_strategy.rs
@@ -1,5 +1,6 @@
-use crate::routing::connection_registry::{BoltServer, ConnectionRegistry};
+use crate::routing::connection_registry::ConnectionRegistry;
 use crate::routing::load_balancing::LoadBalancingStrategy;
+use crate::routing::types::BoltServer;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 

--- a/lib/src/routing/load_balancing/round_robin_strategy.rs
+++ b/lib/src/routing/load_balancing/round_robin_strategy.rs
@@ -103,7 +103,7 @@ mod tests {
         fn fetch_routing_table(
             &self,
             _bookmarks: &[String],
-            db: Option<Database>,
+            _db: Option<Database>,
             _imp_user: Option<ImpersonateUser>,
         ) -> Pin<Box<dyn Future<Output = Result<RoutingTable, Error>> + Send>> {
             unimplemented!()

--- a/lib/src/routing/mod.rs
+++ b/lib/src/routing/mod.rs
@@ -2,6 +2,7 @@ mod connection_registry;
 mod load_balancing;
 mod routed_connection_manager;
 mod routing_table_provider;
+mod types;
 
 use std::fmt::{Display, Formatter};
 #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
@@ -161,8 +162,8 @@ impl Display for RoutingTable {
 }
 
 use crate::config::ImpersonateUser;
-use crate::routing::connection_registry::BoltServer;
 use crate::{Database, Version};
 pub use load_balancing::round_robin_strategy::RoundRobinStrategy;
 pub use routed_connection_manager::RoutedConnectionManager;
 pub use routing_table_provider::ClusterRoutingTableProvider;
+use types::BoltServer;

--- a/lib/src/routing/mod.rs
+++ b/lib/src/routing/mod.rs
@@ -56,15 +56,15 @@ pub struct Server {
 }
 
 #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
-pub struct RouteBuilder<'a> {
+pub struct RouteBuilder {
     routing: Routing,
     bookmarks: Vec<String>,
     db: Option<Database>,
-    imp_user: Option<&'a str>,
+    imp_user: Option<ImpersonateUser>,
 }
 
 #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
-impl<'a> RouteBuilder<'a> {
+impl RouteBuilder {
     pub fn new(routing: Routing, bookmarks: Vec<String>) -> Self {
         Self {
             routing,
@@ -81,8 +81,7 @@ impl<'a> RouteBuilder<'a> {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn with_imp_user(self, imp_user: &'a str) -> Self {
+    pub fn with_imp_user(self, imp_user: ImpersonateUser) -> Self {
         Self {
             imp_user: Some(imp_user),
             ..self
@@ -161,6 +160,7 @@ impl Display for RoutingTable {
     }
 }
 
+use crate::config::ImpersonateUser;
 use crate::routing::connection_registry::BoltServer;
 use crate::{Database, Version};
 pub use load_balancing::round_robin_strategy::RoundRobinStrategy;

--- a/lib/src/routing/routed_connection_manager.rs
+++ b/lib/src/routing/routed_connection_manager.rs
@@ -73,6 +73,7 @@ impl RoutedConnectionManager {
             };
 
             if let Some(pool) = self.connection_registry.get_server_pool(&selected_server) {
+                debug!("Pool status {:?}", pool.status());
                 match pool.get().await {
                     Ok(conn) => return Ok(conn),
                     Err(e) => {

--- a/lib/src/routing/routed_connection_manager.rs
+++ b/lib/src/routing/routed_connection_manager.rs
@@ -1,7 +1,6 @@
+use crate::config::ImpersonateUser;
 use crate::pool::ManagedConnection;
-use crate::routing::connection_registry::{
-    start_background_updater, BoltServer, ConnectionRegistry, RegistryCommand,
-};
+use crate::routing::connection_registry::{BoltServer, ConnectionRegistry};
 use crate::routing::load_balancing::LoadBalancingStrategy;
 use crate::routing::routing_table_provider::RoutingTableProvider;
 use crate::routing::RoundRobinStrategy;
@@ -11,8 +10,7 @@ use crate::{Config, Error, Operation};
 use backon::ExponentialBuilder;
 use futures::lock::Mutex;
 use log::{debug, error};
-use std::{sync::Arc, time::Duration};
-use tokio::sync::mpsc::Sender;
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct RoutedConnectionManager {
@@ -20,22 +18,17 @@ pub struct RoutedConnectionManager {
     connection_registry: Arc<ConnectionRegistry>,
     bookmarks: Arc<Mutex<Vec<String>>>,
     backoff: ExponentialBuilder,
-    channel: Sender<RegistryCommand>,
 }
-
-const ROUTING_TABLE_MAX_WAIT_TIME_MS: i32 = 5000;
 
 impl RoutedConnectionManager {
     pub fn new(config: &Config, provider: Arc<dyn RoutingTableProvider>) -> Result<Self, Error> {
         let backoff = crate::pool::backoff();
-        let connection_registry = Arc::new(ConnectionRegistry::default());
-        let channel = start_background_updater(config, connection_registry.clone(), provider);
+        let connection_registry = Arc::new(ConnectionRegistry::new(config, provider));
         Ok(RoutedConnectionManager {
             load_balancing_strategy: Arc::new(RoundRobinStrategy::new(connection_registry.clone())),
             bookmarks: Arc::new(Mutex::new(vec![])),
             connection_registry,
             backoff,
-            channel,
         })
     }
 
@@ -43,106 +36,74 @@ impl RoutedConnectionManager {
         &self,
         operation: Option<Operation>,
         db: Option<Database>,
+        imp_user: Option<ImpersonateUser>,
+        bookmarks: &[String],
     ) -> Result<ManagedConnection, Error> {
         let op = operation.unwrap_or(Operation::Write);
-        let registry = self.connection_registry.servers(db.clone());
-        // If the registry is empty, we need to refresh the routing table immediately
-        if registry.is_empty() {
-            debug!("Routing table is empty, refreshing");
-            if let Err(error) = self
-                .channel
-                .send(RegistryCommand::RefreshSingleTable((
-                    db.clone(),
-                    self.bookmarks.lock().await.clone(),
-                )))
-                .await
-            {
-                error!("Failed to send refresh command to registry channel");
-                return Err(Error::RoutingTableRefreshFailed(error.to_string()));
-            }
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
+        let servers = self
+            .connection_registry
+            .servers(db.clone(), imp_user.clone(), bookmarks)
+            .await;
 
-        let mut attempts = 0;
         loop {
-            // we loop here until we get a connection. If the routing table is empty, we force a refresh
-            let servers = self.connection_registry.servers(db.clone());
-            if servers.is_empty() {
-                // the first time we need to wait until we get the routing table
-                tokio::time::sleep(Duration::from_millis(10)).await;
-                attempts += 10;
-                if attempts > ROUTING_TABLE_MAX_WAIT_TIME_MS {
-                    // 5 seconds max wait time by default (we don't want to block forever)
-                    error!(
-                        "Failed to get a connection after {} seconds, routing table is still empty",
-                        ROUTING_TABLE_MAX_WAIT_TIME_MS / 1000
-                    );
-                    return Err(Error::ServerUnavailableError(format!(
-                        "Routing table is still empty after {} seconds",
-                        ROUTING_TABLE_MAX_WAIT_TIME_MS / 1000
-                    )));
-                }
-                continue;
-            }
-
-            debug!(
-                "Routing table is now not empty, trying to get a connection for operation: {:?}",
-                op
-            );
-
-            while let Some(server) = match op {
-                Operation::Write => self.select_writer(db.clone()),
-                _ => self.select_reader(db.clone()),
-            } {
-                debug!("requesting connection for server: {:?}", server);
-                if let Some(pool) = self.connection_registry.get_pool(&server) {
-                    match pool.get().await {
-                        Ok(connection) => return Ok(connection),
-                        Err(e) => {
-                            error!(
-                                "Failed to get connection from pool for server `{}`: {}",
-                                server.address, e
-                            );
-                            self.connection_registry
-                                .mark_unavailable(&server, db.clone());
-                            continue;
-                        }
+            let selected_server = match op {
+                Operation::Read => {
+                    if let Some(server) = self.select_reader(&servers) {
+                        debug!("Selected reader: {server:?}");
+                        server
+                    } else {
+                        error!("No available readers in the routing table");
+                        return Err(Error::ServerUnavailableError(format!(
+                            "No available writers in the routing table for operation {op}"
+                        )));
                     }
                 }
+                Operation::Write => {
+                    if let Some(server) = self.select_writer(&servers) {
+                        debug!("Selected writer: {server:?}");
+                        server
+                    } else {
+                        error!("No available writers in the routing table");
+                        return Err(Error::ServerUnavailableError(format!(
+                            "No available writers in the routing table for operation {op}"
+                        )));
+                    }
+                }
+            };
+
+            if let Some(pool) = self.connection_registry.get_server_pool(&selected_server) {
+                match pool.get().await {
+                    Ok(conn) => return Ok(conn),
+                    Err(e) => {
+                        error!("Failed to get connection from pool for server {selected_server:?}: {e}");
+                        self.connection_registry
+                            .mark_unavailable(&selected_server, db.clone());
+                        continue; // Try selecting another server
+                    }
+                }
+            } else {
+                error!("No connection pool found for server: {selected_server:?}");
+                return Err(Error::ServerUnavailableError(format!(
+                    "No connection pool found for server: {selected_server:?}",
+                )));
             }
-            debug!("No connection for requested {op} operation, forcing refresh of the routing table for database `{}`", db.as_deref().unwrap_or("default"));
-            self.channel
-                .send(RegistryCommand::RefreshSingleTable((
-                    db.clone(),
-                    self.bookmarks.lock().await.clone(),
-                )))
-                .await
-                .map_err(|e| {
-                    error!("Failed to send refresh command to registry: {}", e);
-                    Error::RoutingTableRefreshFailed(
-                        "Failed to send refresh command to registry".to_string(),
-                    )
-                })?;
-            // table is not empty, but we couldn't get a connection, so we throw an error
-            break Err(Error::ServerUnavailableError(format!(
-                "No server available for {op} operation on db `{}`",
-                db.as_deref().unwrap_or("default")
-            )));
         }
+    }
+
+    pub async fn get_default_db(&self, imp_user: Option<ImpersonateUser>, bookmarks: &[String]) -> Result<Option<Database>, Error> {
+        self.connection_registry.get_default_db(imp_user, bookmarks).await
     }
 
     pub(crate) fn backoff(&self) -> ExponentialBuilder {
         self.backoff
     }
 
-    fn select_reader(&self, db: Option<Database>) -> Option<BoltServer> {
-        self.load_balancing_strategy
-            .select_reader(&self.connection_registry.servers(db))
+    fn select_reader(&self, servers: &[BoltServer]) -> Option<BoltServer> {
+        self.load_balancing_strategy.select_reader(servers)
     }
 
-    fn select_writer(&self, db: Option<Database>) -> Option<BoltServer> {
-        self.load_balancing_strategy
-            .select_writer(&self.connection_registry.servers(db))
+    fn select_writer(&self, servers: &[BoltServer]) -> Option<BoltServer> {
+        self.load_balancing_strategy.select_writer(servers)
     }
 
     #[allow(dead_code)]

--- a/lib/src/routing/routed_connection_manager.rs
+++ b/lib/src/routing/routed_connection_manager.rs
@@ -70,7 +70,6 @@ impl RoutedConnectionManager {
             };
 
             if let Some(pool) = self.connection_registry.get_server_pool(&selected_server) {
-                debug!("Pool status {:?}", pool.status());
                 match pool.get().await {
                     Ok(conn) => return Ok(conn),
                     Err(e) => {

--- a/lib/src/routing/routed_connection_manager.rs
+++ b/lib/src/routing/routed_connection_manager.rs
@@ -1,8 +1,9 @@
 use crate::config::ImpersonateUser;
 use crate::pool::ManagedConnection;
-use crate::routing::connection_registry::{BoltServer, ConnectionRegistry};
+use crate::routing::connection_registry::ConnectionRegistry;
 use crate::routing::load_balancing::LoadBalancingStrategy;
 use crate::routing::routing_table_provider::RoutingTableProvider;
+use crate::routing::types::BoltServer;
 use crate::routing::RoundRobinStrategy;
 use crate::Database;
 #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
@@ -90,8 +91,14 @@ impl RoutedConnectionManager {
         }
     }
 
-    pub async fn get_default_db(&self, imp_user: Option<ImpersonateUser>, bookmarks: &[String]) -> Result<Option<Database>, Error> {
-        self.connection_registry.get_default_db(imp_user, bookmarks).await
+    pub async fn get_default_db(
+        &self,
+        imp_user: Option<ImpersonateUser>,
+        bookmarks: &[String],
+    ) -> Result<Option<Database>, Error> {
+        self.connection_registry
+            .get_default_db(imp_user, bookmarks)
+            .await
     }
 
     pub(crate) fn backoff(&self) -> ExponentialBuilder {

--- a/lib/src/routing/types.rs
+++ b/lib/src/routing/types.rs
@@ -6,7 +6,7 @@ use std::hash::Hash;
 use std::time::Duration;
 
 /// Represents a Bolt server, with its address, port and role.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct BoltServer {
     pub(crate) address: String,
     pub(crate) port: u16,
@@ -38,22 +38,6 @@ impl BoltServer {
     pub(crate) fn to_neo_url(&self, scheme: &str) -> NeoUrl {
         NeoUrl::parse(&format!("{scheme}://{}:{}", self.address, self.port))
             .expect("Failed to parse BoltServer to NeoUrl")
-    }
-}
-
-impl PartialEq for BoltServer {
-    fn eq(&self, other: &Self) -> bool {
-        self.address == other.address && self.port == other.port && self.role == other.role
-    }
-}
-
-impl Eq for BoltServer {}
-
-impl Hash for BoltServer {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.address.hash(state);
-        self.port.hash(state);
-        self.role.hash(state);
     }
 }
 

--- a/lib/src/routing/types.rs
+++ b/lib/src/routing/types.rs
@@ -39,7 +39,7 @@ impl BoltServer {
 
 impl PartialEq for BoltServer {
     fn eq(&self, other: &Self) -> bool {
-        self.has_same_address(other)
+        self.address == other.address && self.port == other.port && self.role == other.role
     }
 }
 
@@ -49,6 +49,7 @@ impl Hash for BoltServer {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.address.hash(state);
         self.port.hash(state);
+        self.role.hash(state);
     }
 }
 

--- a/lib/src/routing/types.rs
+++ b/lib/src/routing/types.rs
@@ -1,0 +1,113 @@
+use crate::connection::NeoUrl;
+use crate::pool::ConnectionPool;
+use crate::routing::{RoutingTable, Server};
+use crate::utils::ConcurrentHashMap;
+use log::debug;
+use std::hash::Hash;
+use std::time::Duration;
+
+/// Represents a Bolt server, with its address, port and role.
+#[derive(Debug, Clone)]
+pub(crate) struct BoltServer {
+    pub(crate) address: String,
+    pub(crate) port: u16,
+    pub(crate) role: String,
+}
+
+impl BoltServer {
+    pub(crate) fn resolve(server: &Server) -> Vec<Self> {
+        server
+            .addresses
+            .iter()
+            .map(|address| {
+                let bs = NeoUrl::parse(address)
+                    .map(|addr| BoltServer {
+                        address: addr.host().to_string(),
+                        port: addr.port(),
+                        role: server.role.to_string(),
+                    })
+                    .unwrap_or_else(|_| panic!("Failed to parse address {address}"));
+                bs
+            })
+            .collect()
+    }
+
+    pub fn has_same_address(&self, other: &Self) -> bool {
+        self.address == other.address && self.port == other.port
+    }
+}
+
+impl PartialEq for BoltServer {
+    fn eq(&self, other: &Self) -> bool {
+        self.has_same_address(other)
+    }
+}
+
+impl Eq for BoltServer {}
+
+impl Hash for BoltServer {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.address.hash(state);
+        self.port.hash(state);
+    }
+}
+
+/// Represents a table of Bolt servers for a specific database, along with the last update time and TTL.
+/// This is used to manage the routing table for a specific database.
+#[derive(Debug, Clone)]
+pub(crate) struct DatabaseTable {
+    servers: Vec<BoltServer>,
+    last_updated: std::time::Instant,
+    ttl: Duration,
+}
+
+impl Default for DatabaseTable {
+    fn default() -> Self {
+        DatabaseTable {
+            servers: Vec::new(),
+            last_updated: std::time::Instant::now(),
+            ttl: Duration::from_secs(0),
+        }
+    }
+}
+
+impl From<RoutingTable> for DatabaseTable {
+    fn from(table: RoutingTable) -> Self {
+        Self::from(&table)
+    }
+}
+
+impl From<&RoutingTable> for DatabaseTable {
+    fn from(table: &RoutingTable) -> Self {
+        DatabaseTable {
+            servers: table.resolve(),
+            last_updated: std::time::Instant::now(),
+            ttl: Duration::from_secs(table.ttl),
+        }
+    }
+}
+
+impl DatabaseTable {
+    pub(crate) fn is_expired(&self) -> bool {
+        self.last_updated.elapsed() >= self.ttl
+    }
+
+    pub(crate) fn resolve(&self) -> Vec<BoltServer> {
+        self.servers.clone()
+    }
+
+    pub(crate) fn mark_server_unavailable(&mut self, server: &BoltServer) -> bool {
+        if let Some(index) = self.servers.iter().position(|s| server.has_same_address(s)) {
+            self.servers.remove(index);
+            true
+        } else {
+            debug!("Server not found in the database table: {server:?}");
+            false
+        }
+    }
+}
+
+/// A registry of connection pools, indexed by the Bolt server they connect to.
+pub(crate) type PoolRegistry = ConcurrentHashMap<BoltServer, ConnectionPool>;
+/// A map of registries, indexed by the database name.
+pub(crate) type DatabaseServerMap = ConcurrentHashMap<String, DatabaseTable>;

--- a/lib/src/session.rs
+++ b/lib/src/session.rs
@@ -195,9 +195,7 @@ impl Session {
                 .get_default_db(self.imp_user.clone(), &self.bookmarks)
                 .await?;
             self.db = db;
-            self.should_fetch_default_db
-                .compare_exchange(true, false, Relaxed, Relaxed)
-                .unwrap();
+            self.should_fetch_default_db.store(false, Relaxed);
         }
         Ok(())
     }

--- a/lib/src/session.rs
+++ b/lib/src/session.rs
@@ -11,6 +11,12 @@ pub struct SessionConfig {
     bookmarks: Vec<String>,
 }
 
+impl SessionConfig {
+    pub fn builder() -> SessionConfigBuilder {
+        SessionConfigBuilder::default()
+    }
+}
+
 #[derive(Default)]
 pub struct SessionConfigBuilder {
     db: Option<Database>,
@@ -60,9 +66,6 @@ pub struct Session<'a> {
 }
 
 impl<'a> Session<'a> {
-    pub fn builder() -> SessionConfigBuilder {
-        SessionConfigBuilder::default()
-    }
 
     pub(crate) fn new(config: SessionConfig, graph: &'a Graph) -> Session<'a> {
         Self {

--- a/lib/src/session.rs
+++ b/lib/src/session.rs
@@ -1,0 +1,125 @@
+use crate::config::ImpersonateUser;
+use crate::{Database, DetachedRowStream, Error, Graph, Query, RunResult};
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[derive(Default)]
+pub struct SessionConfig {
+    db: Option<Database>,
+    imp_user: Option<ImpersonateUser>,
+    fetch_size: Option<usize>,
+    bookmarks: Vec<String>,
+}
+
+#[derive(Default)]
+pub struct SessionConfigBuilder {
+    db: Option<Database>,
+    imp_user: Option<ImpersonateUser>,
+    fetch_size: Option<usize>,
+    bookmarks: Vec<String>,
+}
+
+impl SessionConfigBuilder {
+    pub fn with_db(mut self, db: Database) -> Self {
+        self.db = Some(db);
+        self
+    }
+
+    pub fn with_imp_user(mut self, imp_user: ImpersonateUser) -> Self {
+        self.imp_user = Some(imp_user);
+        self
+    }
+
+    pub fn with_fetch_size(mut self, fetch_size: usize) -> Self {
+        self.fetch_size = Some(fetch_size);
+        self
+    }
+
+    pub fn with_bookmarks(mut self, bookmarks: Vec<String>) -> Self {
+        self.bookmarks = bookmarks;
+        self
+    }
+
+    pub fn build(self) -> SessionConfig {
+        SessionConfig {
+            db: self.db,
+            imp_user: self.imp_user,
+            fetch_size: self.fetch_size,
+            bookmarks: self.bookmarks,
+        }
+    }
+}
+
+pub struct Session<'a> {
+    db: Option<Database>,
+    imp_user: Option<ImpersonateUser>,
+    fetch_size: Option<usize>,
+    bookmarks: Vec<String>,
+    should_fetch_default_db: AtomicBool,
+    driver: &'a Graph,
+}
+
+impl<'a> Session<'a> {
+    pub(crate) fn new(config: SessionConfig, graph: &'a Graph) -> Session<'a> {
+        Self {
+            db: config.db,
+            imp_user: config.imp_user,
+            fetch_size: config.fetch_size,
+            bookmarks: config.bookmarks,
+            should_fetch_default_db: AtomicBool::new(true),
+            driver: graph,
+        }
+    }
+
+    pub async fn run(&mut self, query: impl Into<Query>) -> crate::Result<RunResult> {
+        self.update_db_name().await?;
+        match self
+            .driver
+            .impl_run_on(
+                self.db.clone(),
+                self.imp_user.clone(),
+                &self.bookmarks,
+                query.into(),
+            )
+            .await
+        {
+            Ok(result) => {
+                if let Some(bookmark) = result.bookmark.as_ref() {
+                    self.bookmarks.push(bookmark.clone());
+                }
+                Ok(result)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    pub async fn execute(&mut self, query: impl Into<Query>) -> crate::Result<DetachedRowStream> {
+        self.update_db_name().await?;
+        self.driver
+            .impl_execute_on(
+                self.db.clone(),
+                self.imp_user.clone(),
+                &self.bookmarks,
+                query.into(),
+            )
+            .await
+    }
+
+    async fn update_db_name(&mut self) -> Result<(), Error> {
+        if self.db.is_none()
+            && self
+            .should_fetch_default_db
+            .fetch_or(false, Ordering::Relaxed)
+        {
+            let db = self
+                .driver
+                .get_default_db(self.imp_user.clone(), &self.bookmarks)
+                .await?;
+            self.db = db;
+            self.should_fetch_default_db
+                .compare_exchange(true, false, Relaxed, Relaxed)
+                .unwrap();
+        }
+        Ok(())
+    }
+}

--- a/lib/src/session.rs
+++ b/lib/src/session.rs
@@ -66,7 +66,6 @@ pub struct Session<'a> {
 }
 
 impl<'a> Session<'a> {
-
     pub(crate) fn new(config: SessionConfig, graph: &'a Graph) -> Session<'a> {
         Self {
             db: config.db,
@@ -115,8 +114,8 @@ impl<'a> Session<'a> {
     async fn update_db_name(&mut self) -> Result<(), Error> {
         if self.db.is_none()
             && self
-            .should_fetch_default_db
-            .fetch_or(false, Ordering::Relaxed)
+                .should_fetch_default_db
+                .fetch_or(false, Ordering::Relaxed)
         {
             let db = self
                 .driver

--- a/lib/src/session.rs
+++ b/lib/src/session.rs
@@ -60,6 +60,10 @@ pub struct Session<'a> {
 }
 
 impl<'a> Session<'a> {
+    pub fn builder() -> SessionConfigBuilder {
+        SessionConfigBuilder::default()
+    }
+
     pub(crate) fn new(config: SessionConfig, graph: &'a Graph) -> Session<'a> {
         Self {
             db: config.db,

--- a/lib/src/session.rs
+++ b/lib/src/session.rs
@@ -85,6 +85,7 @@ impl<'a> Session<'a> {
                 self.db.clone(),
                 self.imp_user.clone(),
                 &self.bookmarks,
+                self.fetch_size,
                 query.into(),
             )
             .await
@@ -106,6 +107,7 @@ impl<'a> Session<'a> {
                 self.db.clone(),
                 self.imp_user.clone(),
                 &self.bookmarks,
+                self.fetch_size,
                 query.into(),
             )
             .await

--- a/lib/src/txn.rs
+++ b/lib/src/txn.rs
@@ -7,6 +7,7 @@ use {
     log::debug,
 };
 
+use crate::config::ImpersonateUser;
 use crate::{
     config::Database, errors::Result, pool::ManagedConnection, query::Query, stream::RowStream,
     Operation, RunResult,
@@ -21,6 +22,7 @@ pub struct Txn {
     fetch_size: usize,
     connection: ManagedConnection,
     operation: Operation,
+    imp_user: Option<ImpersonateUser>,
     #[allow(dead_code)]
     bookmark: Option<String>,
 }
@@ -32,6 +34,7 @@ impl Txn {
         fetch_size: usize,
         mut connection: ManagedConnection,
         operation: Operation,
+        imp_user: Option<ImpersonateUser>,
     ) -> Result<Self> {
         let begin = BoltRequest::begin(db.as_deref());
         match connection.send_recv(begin).await? {
@@ -41,6 +44,7 @@ impl Txn {
                 connection,
                 operation,
                 bookmark: None,
+                imp_user,
             }),
             msg => Err(msg.into_error("BEGIN")),
         }
@@ -52,6 +56,7 @@ impl Txn {
         fetch_size: usize,
         mut connection: ManagedConnection,
         operation: Operation,
+        imp_user: Option<ImpersonateUser>,
         bookmarks: &[String],
     ) -> Result<Self> {
         debug!("Starting transaction with bookmarks: {:?}", bookmarks);
@@ -65,6 +70,7 @@ impl Txn {
                 connection,
                 operation,
                 bookmark: None,
+                imp_user,
             }),
             Summary::Ignored => Err(crate::errors::Error::Ignored("Failed to start transaction")),
             Summary::Failure(failure) => Err(failure.into_error()),
@@ -80,7 +86,8 @@ impl Txn {
     ) -> Result<crate::summary::Counters> {
         let mut counters = crate::summary::Counters::default();
         for query in queries {
-            let summary = self.run(query.into()).await?;
+            let q = query.into().imp_user(self.imp_user.clone());
+            let summary = self.run(q).await?;
             counters += summary.stats();
             self.save_bookmark_state(&summary);
         }
@@ -94,7 +101,8 @@ impl Txn {
         queries: impl IntoIterator<Item = Q>,
     ) -> Result<()> {
         for query in queries {
-            self.run(query.into()).await?;
+            let q = query.into().imp_user(self.imp_user.clone());
+            self.run(q).await?;
         }
         Ok(())
     }

--- a/lib/src/txn.rs
+++ b/lib/src/txn.rs
@@ -23,7 +23,7 @@ pub struct Txn {
     connection: ManagedConnection,
     operation: Operation,
     imp_user: Option<ImpersonateUser>,
-    #[allow(dead_code)]
+    #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
     bookmark: Option<String>,
 }
 
@@ -43,7 +43,6 @@ impl Txn {
                 fetch_size,
                 connection,
                 operation,
-                bookmark: None,
                 imp_user,
             }),
             msg => Err(msg.into_error("BEGIN")),

--- a/lib/src/utils/concurrent_hashmap.rs
+++ b/lib/src/utils/concurrent_hashmap.rs
@@ -1,0 +1,184 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::{Arc, RwLock};
+
+pub struct ConcurrentHashMap<K, V> {
+    inner: Arc<RwLock<HashMap<K, V>>>,
+}
+
+impl<K, V> ConcurrentHashMap<K, V>
+where
+    K: Eq + Hash + Clone,
+    V: Clone,
+{
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::with_capacity(capacity))),
+        }
+    }
+
+    pub fn insert(&self, key: K, value: V) -> Option<V> {
+        let mut map = self.inner.write().unwrap();
+        map.insert(key, value)
+    }
+
+    pub fn get(&self, key: &K) -> Option<V> {
+        let map = self.inner.read().unwrap();
+        map.get(key).cloned()
+    }
+
+    pub fn remove(&self, key: &K) -> Option<V> {
+        let mut map = self.inner.write().unwrap();
+        map.remove(key)
+    }
+
+    pub fn contains_key(&self, key: &K) -> bool {
+        let map = self.inner.read().unwrap();
+        map.contains_key(key)
+    }
+
+    pub fn len(&self) -> usize {
+        let map = self.inner.read().unwrap();
+        map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        let map = self.inner.read().unwrap();
+        map.is_empty()
+    }
+
+    pub fn clear(&self) {
+        let mut map = self.inner.write().unwrap();
+        map.clear();
+    }
+
+    pub fn keys(&self) -> Vec<K> {
+        let map = self.inner.read().unwrap();
+        map.keys().cloned().collect()
+    }
+
+    pub fn values(&self) -> Vec<V> {
+        let map = self.inner.read().unwrap();
+        map.values().cloned().collect()
+    }
+
+    pub fn insert_or_update<F>(&self, key: K, value: V, update_fn: F) -> V
+    where
+        F: FnOnce(&V) -> V,
+    {
+        let mut map = self.inner.write().unwrap();
+        match map.get(&key) {
+            Some(existing_value) => {
+                let new_value = update_fn(existing_value);
+                map.insert(key, new_value.clone());
+                new_value
+            }
+            None => {
+                map.insert(key, value.clone());
+                value
+            }
+        }
+    }
+
+    pub fn with_read<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&HashMap<K, V>) -> R,
+    {
+        let map = self.inner.read().unwrap();
+        f(&*map)
+    }
+
+    pub fn with_write<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&mut HashMap<K, V>) -> R,
+    {
+        let mut map = self.inner.write().unwrap();
+        f(&mut *map)
+    }
+}
+
+impl<K, V> Clone for ConcurrentHashMap<K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<K, V> Default for ConcurrentHashMap<K, V>
+where
+    K: Eq + Hash + Clone,
+    V: Clone,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn test_basic_operations() {
+        let map = ConcurrentHashMap::new();
+        
+        // Test insert e get
+        assert_eq!(map.insert("key1".to_string(), 42), None);
+        assert_eq!(map.get(&"key1".to_string()), Some(42));
+        
+        // Test update
+        assert_eq!(map.insert("key1".to_string(), 84), Some(42));
+        assert_eq!(map.get(&"key1".to_string()), Some(84));
+        
+        // Test contains_key
+        assert!(map.contains_key(&"key1".to_string()));
+        assert!(!map.contains_key(&"key2".to_string()));
+        
+        // Test remove
+        assert_eq!(map.remove(&"key1".to_string()), Some(84));
+        assert_eq!(map.get(&"key1".to_string()), None);
+    }
+
+    #[test]
+    fn test_concurrent_access() {
+        let map = ConcurrentHashMap::new();
+        let map_clone = map.clone();
+        
+        // Thread writer
+        let writer = thread::spawn(move || {
+            for i in 0..100 {
+                map_clone.insert(i, i * 2);
+                thread::sleep(Duration::from_millis(1));
+            }
+        });
+        
+        // Thread readers
+        let mut readers = vec![];
+        for _ in 0..3 {
+            let map_clone = map.clone();
+            let reader = thread::spawn(move || {
+                for i in 0..100 {
+                    let _ = map_clone.get(&i);
+                    thread::sleep(Duration::from_millis(1));
+                }
+            });
+            readers.push(reader);
+        }
+        
+        writer.join().unwrap();
+        for reader in readers {
+            reader.join().unwrap();
+        }
+        
+        assert_eq!(map.len(), 100);
+    }
+}

--- a/lib/src/utils/concurrent_hashmap.rs
+++ b/lib/src/utils/concurrent_hashmap.rs
@@ -6,6 +6,7 @@ pub struct ConcurrentHashMap<K, V> {
     inner: Arc<RwLock<HashMap<K, V>>>,
 }
 
+#[allow(dead_code)]
 impl<K, V> ConcurrentHashMap<K, V>
 where
     K: Eq + Hash + Clone,

--- a/lib/src/utils/concurrent_hashmap.rs
+++ b/lib/src/utils/concurrent_hashmap.rs
@@ -1,3 +1,4 @@
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::sync::{Arc, RwLock};
@@ -74,14 +75,14 @@ where
         F: FnOnce(&V) -> V,
     {
         let mut map = self.inner.write().unwrap();
-        match map.get(&key) {
-            Some(existing_value) => {
-                let new_value = update_fn(existing_value);
-                map.insert(key, new_value.clone());
+        match map.entry(key) {
+            Entry::Occupied(mut occupied) => {
+                let new_value = update_fn(occupied.get());
+                occupied.insert(new_value.clone());
                 new_value
             }
-            None => {
-                map.insert(key, value.clone());
+            Entry::Vacant(vacant) => {
+                vacant.insert(value.clone());
                 value
             }
         }

--- a/lib/src/utils/concurrent_hashmap.rs
+++ b/lib/src/utils/concurrent_hashmap.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::hash::Hash;
@@ -30,7 +31,11 @@ where
         map.insert(key, value)
     }
 
-    pub fn get(&self, key: &K) -> Option<V> {
+    pub fn get<Q>(&self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
         let map = self.inner.read().unwrap();
         map.get(key).cloned()
     }

--- a/lib/src/utils/concurrent_hashmap.rs
+++ b/lib/src/utils/concurrent_hashmap.rs
@@ -130,19 +130,19 @@ mod tests {
     #[test]
     fn test_basic_operations() {
         let map = ConcurrentHashMap::new();
-        
+
         // Test insert e get
         assert_eq!(map.insert("key1".to_string(), 42), None);
         assert_eq!(map.get(&"key1".to_string()), Some(42));
-        
+
         // Test update
         assert_eq!(map.insert("key1".to_string(), 84), Some(42));
         assert_eq!(map.get(&"key1".to_string()), Some(84));
-        
+
         // Test contains_key
         assert!(map.contains_key(&"key1".to_string()));
         assert!(!map.contains_key(&"key2".to_string()));
-        
+
         // Test remove
         assert_eq!(map.remove(&"key1".to_string()), Some(84));
         assert_eq!(map.get(&"key1".to_string()), None);
@@ -152,7 +152,7 @@ mod tests {
     fn test_concurrent_access() {
         let map = ConcurrentHashMap::new();
         let map_clone = map.clone();
-        
+
         // Thread writer
         let writer = thread::spawn(move || {
             for i in 0..100 {
@@ -160,7 +160,7 @@ mod tests {
                 thread::sleep(Duration::from_millis(1));
             }
         });
-        
+
         // Thread readers
         let mut readers = vec![];
         for _ in 0..3 {
@@ -173,12 +173,12 @@ mod tests {
             });
             readers.push(reader);
         }
-        
+
         writer.join().unwrap();
         for reader in readers {
             reader.join().unwrap();
         }
-        
+
         assert_eq!(map.len(), 100);
     }
 }

--- a/lib/src/utils/mod.rs
+++ b/lib/src/utils/mod.rs
@@ -1,0 +1,3 @@
+mod concurrent_hashmap;
+
+pub use concurrent_hashmap::ConcurrentHashMap;

--- a/lib/tests/use_default_db.rs
+++ b/lib/tests/use_default_db.rs
@@ -1,7 +1,5 @@
 use futures::TryStreamExt;
 use neo4rs::query;
-#[cfg(feature = "unstable-bolt-protocol-impl-v2")]
-use neo4rs::Operation;
 
 mod container;
 
@@ -18,7 +16,7 @@ async fn use_default_db() {
         Ok(n) => n,
         Err(e) => {
             if e.to_string().contains("Neo4j Enterprise Edition") {
-                eprintln!("Skipping test: {}", e);
+                eprintln!("Skipping test: {e}");
                 return;
             }
 
@@ -29,7 +27,7 @@ async fn use_default_db() {
 
     #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
     let query_stream = graph
-        .execute_on("system", "SHOW DEFAULT DATABASE", Operation::Read)
+        .execute_on("system", "SHOW DEFAULT DATABASE")
         .await;
 
     #[cfg(not(feature = "unstable-bolt-protocol-impl-v2"))]
@@ -70,8 +68,7 @@ async fn use_default_db() {
             query!(
                 "MATCH (n:Node {{uuid: {uuid}}}) RETURN count(n) AS result",
                 uuid = id.to_string()
-            ),
-            Operation::Read,
+            )
         )
         .await;
 

--- a/lib/tests/use_default_db.rs
+++ b/lib/tests/use_default_db.rs
@@ -1,5 +1,5 @@
 use futures::TryStreamExt;
-use neo4rs::query;
+use neo4rs::{query, Operation};
 
 mod container;
 
@@ -26,7 +26,9 @@ async fn use_default_db() {
     let graph = neo4j.graph();
 
     #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
-    let query_stream = graph.execute_on("system", "SHOW DEFAULT DATABASE").await;
+    let query_stream = graph
+        .execute_on(Operation::Read, "system", "SHOW DEFAULT DATABASE")
+        .await;
 
     #[cfg(not(feature = "unstable-bolt-protocol-impl-v2"))]
     let query_stream = graph.execute_on("system", "SHOW DEFAULT DATABASE").await;
@@ -62,6 +64,7 @@ async fn use_default_db() {
     #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
     let query_stream = graph
         .execute_on(
+            Operation::Read,
             dbname.as_str(),
             query!(
                 "MATCH (n:Node {{uuid: {uuid}}}) RETURN count(n) AS result",

--- a/lib/tests/use_default_db.rs
+++ b/lib/tests/use_default_db.rs
@@ -26,9 +26,7 @@ async fn use_default_db() {
     let graph = neo4j.graph();
 
     #[cfg(feature = "unstable-bolt-protocol-impl-v2")]
-    let query_stream = graph
-        .execute_on("system", "SHOW DEFAULT DATABASE")
-        .await;
+    let query_stream = graph.execute_on("system", "SHOW DEFAULT DATABASE").await;
 
     #[cfg(not(feature = "unstable-bolt-protocol-impl-v2"))]
     let query_stream = graph.execute_on("system", "SHOW DEFAULT DATABASE").await;
@@ -68,7 +66,7 @@ async fn use_default_db() {
             query!(
                 "MATCH (n:Node {{uuid: {uuid}}}) RETURN count(n) AS result",
                 uuid = id.to_string()
-            )
+            ),
         )
         .await;
 


### PR DESCRIPTION
This PR introduces the concept of sessions when enabling the feature flag unstable-bolt-protocol-impl-v2.

The driver now provides a with_session method, allowing a session to be created on an existing connection. Sessions can be used to specify the target database, impersonate a user, and set the fetch size for queries. Bookmark handling has also been corrected to work properly within sessions.

Additionally, this PR updates the routing logic, as support for user impersonation required changes in that area.

Unfortunately, the changes are many and the PR is quite big.

**Routing Refactor**

Due to a **deadlock** caused by the use of DashMaps in the connection registry, this PR includes a complete refactor of the routing protocol. The router is now lazy and no longer relies on a separate task to fetch routing tables. This simplifies the design and improves code readability.

**Graph Structure API**

The PR changes the Graph structure API: the method `execute_on` is now forcing the user to pass the operation to perform (read or write) in order to pick the right server from the routing table.

