### PR TITLE
Add conversions for chrono's UTC type

### DIFF
--- a/lib/src/convert.rs
+++ b/lib/src/convert.rs
@@ -285,6 +285,12 @@ impl From<chrono::DateTime<chrono::FixedOffset>> for BoltType {
     }
 }
 
+impl From<chrono::DateTime<chrono::Utc>> for BoltType {
+    fn from(value: chrono::DateTime<chrono::Utc>) -> Self {
+        BoltType::DateTime(value.into())
+    }
+}
+
 impl From<(chrono::NaiveTime, chrono::FixedOffset)> for BoltType {
     fn from(value: (chrono::NaiveTime, chrono::FixedOffset)) -> Self {
         BoltType::Time(value.into())

--- a/lib/src/types/serde/typ.rs
+++ b/lib/src/types/serde/typ.rs
@@ -1579,6 +1579,17 @@ mod tests {
     }
 
     #[test]
+    fn datetime_utc() {
+        let expected = test_datetime();
+
+        let datetime = BoltDateTime::from(expected);
+        let datetime = BoltType::DateTime(datetime);
+
+        let actual = datetime.to::<DateTime<Utc>>().unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn datetime_nanoseconds() {
         #[derive(Debug, PartialEq, Deserialize)]
         #[serde(transparent)]


### PR DESCRIPTION
We use `Utc::now()` a lot. This helps for serialization.