### PR TITLE
RUSTSEC-2025-0134: rustls-pemfile is unmaintained

### DIFF
--- a/ci/Cargo.lock.min
+++ b/ci/Cargo.lock.min
@@ -764,7 +764,7 @@ dependencies = [
  "pretty_env_logger",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -1068,15 +1068,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/ci/Cargo.lock.msrv
+++ b/ci/Cargo.lock.msrv
@@ -764,7 +764,7 @@ dependencies = [
  "pretty_env_logger",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -1068,15 +1068,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -40,7 +40,7 @@ neo4rs-macros = { version = "0.3.0", path = "../macros" }
 pastey = "0.2.0"
 pin-project-lite = "0.2.9"
 rustls-native-certs = "0.8.0"
-rustls-pemfile = "2.1.2"
+rustls-pki-types = "1.9.0"
 serde = { version = "1.0.185", features = ["derive"] }                     # TODO: eliminate derive
 serde_json = { version = "1.0.0", optional = true }
 thiserror = "2.0.0"

--- a/lib/src/connection.rs
+++ b/lib/src/connection.rs
@@ -23,7 +23,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use log::{info, warn};
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::crypto::CryptoProvider;
-use rustls::pki_types::{CertificateDer, UnixTime};
+use rustls::pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer, UnixTime};
 use rustls::{DigitallySignedStruct, SignatureScheme};
 use std::fmt::{Debug, Display, Formatter};
 use std::time::Duration;
@@ -511,8 +511,8 @@ impl ConnectionInfo {
             }
             ConnectionTLSConfig::ClientCACertificate(certificate) => {
                 let cert_file = File::open(&certificate.cert_file)?;
-                let mut reader = BufReader::new(cert_file);
-                let certs = rustls_pemfile::certs(&mut reader).flatten();
+                let reader = BufReader::new(cert_file);
+                let certs = CertificateDer::pem_reader_iter(reader).flatten();
                 root_cert_store.add_parsable_certificates(certs);
                 builder
                     .with_root_certificates(root_cert_store)
@@ -524,17 +524,19 @@ impl ConnectionInfo {
                 .with_no_client_auth(),
             ConnectionTLSConfig::MutualTLS(mutual) => {
                 let cert_file = File::open(&mutual.client_cert)?;
-                let mut cert_reader = BufReader::new(cert_file);
-                let cert_certs = rustls_pemfile::certs(&mut cert_reader).flatten();
+                let cert_reader = BufReader::new(cert_file);
+                let cert_certs = CertificateDer::pem_reader_iter(cert_reader).flatten();
 
                 let cert_key = File::open(&mutual.client_key)?;
-                let mut key_reader = BufReader::new(cert_key);
-                let keys = rustls_pemfile::private_key(&mut key_reader);
-                let keys = keys?.unwrap();
+                let key_reader = BufReader::new(cert_key);
+                let keys = PrivateKeyDer::pem_reader_iter(key_reader)
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(std::io::Error::other);
+                let keys = keys?.pop().unwrap();
                 if mutual.cert_file.is_some() {
                     let root_cert_file = File::open(mutual.cert_file.as_ref().unwrap())?;
-                    let mut root_reader = BufReader::new(root_cert_file);
-                    let root_certs = rustls_pemfile::certs(&mut root_reader).flatten();
+                    let root_reader = BufReader::new(root_cert_file);
+                    let root_certs = CertificateDer::pem_reader_iter(root_reader).flatten();
                     root_cert_store.add_parsable_certificates(root_certs);
                     builder
                         .with_root_certificates(root_cert_store)


### PR DESCRIPTION
Replace unmaintained dependency as recommended by https://github.com/rustls/pemfile/issues/61